### PR TITLE
Update: use gtags only on production site

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -46,7 +46,7 @@
   
     <!-- Google tag (gtag.js) -->
       <!-- Google Analytics (Auto-disable on staging domains) -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=G-EKW7WYG510">
+      <script>
           (function () {
               const PROD_DOMAIN = "nairobidevops.org";
               if (window.location.hostname !== PROD_DOMAIN) {


### PR DESCRIPTION
 Changes to be committed:
	modified:   client/index.html



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts Google Analytics (gtag) to the production domain (nairobidevops.org). Staging and local hosts skip loading GA to prevent test traffic in analytics.

<sup>Written for commit b40f1ab2faf796e09b5337ed8c2570a0c4622563. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics now initializes only when the site is served from the designated production domain; on other domains it is automatically disabled and emits a console warning.
  * Prevents unconditional loading of analytics on non-production deployments, reducing accidental telemetry and protecting test/staging environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->