### PR TITLE
feat: Introduce a pre-staging quality gates workflow and new PHP API …

### DIFF
--- a/client/public/api/luma.php
+++ b/client/public/api/luma.php
@@ -95,12 +95,13 @@ $queryString = http_build_query($queryParams);
 $target_url = $base_url . $path . ($queryString ? '?' . $queryString : '');
 
 // 7. Caching (GET requests only)
-$authContext = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+$authContext = $headersLower['authorization'] ?? $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+$hasAuthorization = trim($authContext) !== '';
 $cacheKey = md5($target_url . '|' . $authContext);
 $cacheFile = $cacheRootDir . '/api_responses/luma_' . $cacheKey . '.json';
 $cacheTTL = 300; // 5 minutes
 
-if ($method === 'GET' && file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTTL)) {
+if ($method === 'GET' && !$hasAuthorization && file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTTL)) {
     $cachedData = file_get_contents($cacheFile);
     $cacheMetaFile = $cacheFile . '.meta';
     $cachedContentType = file_exists($cacheMetaFile) ? file_get_contents($cacheMetaFile) : 'application/json; charset=utf-8';
@@ -129,7 +130,7 @@ if (in_array($method, ['POST', 'PUT', 'PATCH'])) {
 
 // Forward Authorization
 $forwardHeaders = [];
-$forwardAuthHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? null;
+$forwardAuthHeader = !empty($authContext) ? $authContext : null;
 if ($forwardAuthHeader) $forwardHeaders[] = 'Authorization: ' . preg_replace('/\v+/', '', $forwardAuthHeader);
 if (isset($_SERVER['CONTENT_TYPE'])) $forwardHeaders[] = 'Content-Type: ' . preg_replace('/\v+/', '', $_SERVER['CONTENT_TYPE']);
 if (!empty($forwardHeaders)) curl_setopt($ch, CURLOPT_HTTPHEADER, $forwardHeaders);
@@ -151,9 +152,9 @@ curl_close($ch);
 // 8. Cache result and output
 http_response_code($http_code);
 header('Content-Type: ' . ($contentType ?: 'application/json; charset=utf-8'));
-header('X-Cache: MISS');
+header('X-Cache: ' . ($hasAuthorization ? 'BYPASS' : 'MISS'));
 
-if ($method === 'GET' && $http_code === 200) {
+if ($method === 'GET' && !$hasAuthorization && $http_code === 200) {
     if (!is_dir(dirname($cacheFile))) mkdir(dirname($cacheFile), 0700, true);
     // Atomic write
     file_put_contents($cacheFile . '.tmp', $response, LOCK_EX);

--- a/client/public/api/security-utils.php
+++ b/client/public/api/security-utils.php
@@ -60,7 +60,7 @@ class SecurityUtils {
             $normalized = self::normalizeOrigin($allowed);
             if ($normalized !== null) {
                 if (isset($normalizedAllowedOrigins[$normalized])) {
-                    error_log("SecurityUtils::normalizeOrigin: Duplicate normalized origin detected. '$allowed' and '{$normalizedAllowedOrigins[$normalized]}' both normalize to '$normalized'. Using the latter.");
+                    error_log("SecurityUtils::normalizeOrigin: Duplicate normalized origin detected. '$allowed' and '{$normalizedAllowedOrigins[$normalized]}' both normalize to '$normalized'. Overwriting with the new value.");
                 }
                 $normalizedAllowedOrigins[$normalized] = rtrim($allowed, '/');
             }

--- a/client/public/api/security-utils.php
+++ b/client/public/api/security-utils.php
@@ -5,6 +5,39 @@
 
 class SecurityUtils {
     /**
+     * Normalize an origin string to strict scheme://host[:port] form.
+     * Returns null for invalid/unsupported origins.
+     */
+    private static function normalizeOrigin($origin) {
+        if (!is_string($origin) || trim($origin) === '') {
+            return null;
+        }
+
+        $parts = parse_url(trim($origin));
+        if (!$parts || !isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            return null;
+        }
+
+        $host = strtolower($parts['host']);
+        $normalized = $scheme . '://' . $host;
+
+        if (isset($parts['port'])) {
+            $port = (int)$parts['port'];
+            $isDefaultPort = ($scheme === 'http' && $port === 80) || ($scheme === 'https' && $port === 443);
+            if (!$isDefaultPort) {
+                $normalized .= ':' . $port;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
      * Get real IP, resistant to spoofing if we know we are behind a trusted proxy.
      * In a standard cPanel environment, REMOTE_ADDR is usually the most reliable
      * unless a specific proxy (like Cloudflare) is used and configured.
@@ -22,36 +55,30 @@ class SecurityUtils {
         
         $origin = $_SERVER['HTTP_ORIGIN'] ?? ($headersLower['origin'] ?? '');
         $referer = $_SERVER['HTTP_REFERER'] ?? ($headersLower['referer'] ?? '');
+        $normalizedAllowedOrigins = [];
+        foreach ($allowedOrigins as $allowed) {
+            $normalized = self::normalizeOrigin($allowed);
+            if ($normalized !== null) {
+                if (isset($normalizedAllowedOrigins[$normalized])) {
+                    error_log("SecurityUtils::normalizeOrigin: Duplicate normalized origin detected. '$allowed' and '{$normalizedAllowedOrigins[$normalized]}' both normalize to '$normalized'. Using the latter.");
+                }
+                $normalizedAllowedOrigins[$normalized] = rtrim($allowed, '/');
+            }
+        }
 
         // 1. Precise Origin check
         if (!empty($origin)) {
-            $originTrimmed = rtrim($origin, '/');
-            foreach ($allowedOrigins as $allowed) {
-                if ($originTrimmed === rtrim($allowed, '/')) {
-                    return $allowed;
-                }
+            $normalizedOrigin = self::normalizeOrigin($origin);
+            if ($normalizedOrigin !== null && isset($normalizedAllowedOrigins[$normalizedOrigin])) {
+                return $normalizedAllowedOrigins[$normalizedOrigin];
             }
         }
         
-        // 2. Fallback to Referer check
+        // 2. Fallback to Referer origin check
         if (!empty($referer)) {
-            $refererParts = parse_url($referer);
-            if ($refererParts && isset($refererParts['scheme'], $refererParts['host'])) {
-                $refererOrigin = $refererParts['scheme'] . '://' . $refererParts['host'];
-                if (isset($refererParts['port'])) {
-                    // Normalize: only append port if it's not the default for the scheme
-                    $port = (int)$refererParts['port'];
-                    if (($refererParts['scheme'] === 'http' && $port !== 80) || 
-                        ($refererParts['scheme'] === 'https' && $port !== 443)) {
-                        $refererOrigin .= ':' . $port;
-                    }
-                }
-
-                foreach ($allowedOrigins as $allowed) {
-                    if (rtrim($refererOrigin, '/') === rtrim($allowed, '/')) {
-                        return $allowed;
-                    }
-                }
+            $normalizedRefererOrigin = self::normalizeOrigin($referer);
+            if ($normalizedRefererOrigin !== null && isset($normalizedAllowedOrigins[$normalizedRefererOrigin])) {
+                return $normalizedAllowedOrigins[$normalizedRefererOrigin];
             }
         }
 

--- a/client/src/hooks/useCloudinaryFolder.ts
+++ b/client/src/hooks/useCloudinaryFolder.ts
@@ -16,7 +16,7 @@ export function useCloudinaryFolder(folder: CloudinaryFolder) {
   const fetchImages = useCallback(
     async (cursor?: string, signal?: AbortSignal) => {
       const requestId = ++requestIdRef.current;
-      
+
       try {
         if (cursor) {
           if (inFlightCursor.current === cursor) return;

--- a/client/src/hooks/useCloudinaryFolder.ts
+++ b/client/src/hooks/useCloudinaryFolder.ts
@@ -11,9 +11,12 @@ export function useCloudinaryFolder(folder: CloudinaryFolder) {
   const [hasMore, setHasMore] = useState(false);
   const inFlightCursor = useRef<string | null | undefined>(null);
   const loadMoreController = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
 
   const fetchImages = useCallback(
     async (cursor?: string, signal?: AbortSignal) => {
+      const requestId = ++requestIdRef.current;
+      
       try {
         if (cursor) {
           if (inFlightCursor.current === cursor) return;
@@ -54,24 +57,32 @@ export function useCloudinaryFolder(folder: CloudinaryFolder) {
 
         const fetchedResources = data?.images ?? [];
 
-        setImages((prev) => (cursor ? [...prev, ...fetchedResources] : fetchedResources));
-        setNextCursor(data.nextCursor);
-        setHasMore(data.hasMore);
+        // Only update state if this is still the latest request
+        if (requestId === requestIdRef.current) {
+          setImages((prev) => (cursor ? [...prev, ...fetchedResources] : fetchedResources));
+          setNextCursor(data.nextCursor);
+          setHasMore(data.hasMore);
+        }
       } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") {
-          // Silent for normal control flow
-        } else {
-          setError(err instanceof Error ? err.message : "An unknown error occurred");
+        if (requestId === requestIdRef.current) {
+          if (err instanceof DOMException && err.name === "AbortError") {
+            return; // AbortError is expected, ignore for normal control flow
+          } else {
+            setError(err instanceof Error ? err.message : "An unknown error occurred");
+          }
         }
       } finally {
-        if (cursor) {
-          setLoadingMore(false);
-          // Only clear if the cursor we started with is still the one in flight
-          if (cursor === inFlightCursor.current) {
-            inFlightCursor.current = null;
+        // Only update loading state if this is still the latest request
+        if (requestId === requestIdRef.current) {
+          if (cursor) {
+            setLoadingMore(false);
+            // Only clear if the cursor we started with is still the one in flight
+            if (cursor === inFlightCursor.current) {
+              inFlightCursor.current = null;
+            }
+          } else {
+            setLoading(false);
           }
-        } else {
-          setLoading(false);
         }
       }
     },
@@ -86,6 +97,7 @@ export function useCloudinaryFolder(folder: CloudinaryFolder) {
     setNextCursor(undefined);
     setHasMore(false);
     setLoadingMore(false);
+    inFlightCursor.current = null;
 
     fetchImages(undefined, controller.signal);
     return () => {

--- a/client/src/hooks/useCloudinaryFolder.ts
+++ b/client/src/hooks/useCloudinaryFolder.ts
@@ -52,8 +52,6 @@ export function useCloudinaryFolder(folder: CloudinaryFolder) {
 
         const data: CloudinaryResponse = await response.json();
 
-        if (signal?.aborted) return;
-
         const fetchedResources = data?.images ?? [];
 
         setImages((prev) => (cursor ? [...prev, ...fetchedResources] : fetchedResources));
@@ -61,19 +59,19 @@ export function useCloudinaryFolder(folder: CloudinaryFolder) {
         setHasMore(data.hasMore);
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
-          if (cursor === inFlightCursor.current) {
-            inFlightCursor.current = null;
-          }
-          return;
+          // Silent for normal control flow
+        } else {
+          setError(err instanceof Error ? err.message : "An unknown error occurred");
         }
-        setError(err instanceof Error ? err.message : "An unknown error occurred");
       } finally {
-        if (!signal?.aborted) {
-          setLoading(false);
+        if (cursor) {
           setLoadingMore(false);
+          // Only clear if the cursor we started with is still the one in flight
           if (cursor === inFlightCursor.current) {
             inFlightCursor.current = null;
           }
+        } else {
+          setLoading(false);
         }
       }
     },


### PR DESCRIPTION
…endpoints for image handling, Luma integration, and security utilities.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/264)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved auth-aware caching for Luma, tightened origin validation, and hardened Cloudinary folder loading to prevent stale updates in pre-staging quality gates.

- **Bug Fixes**
  - Luma API: Bypass GET cache when Authorization is present; X-Cache returns BYPASS for authorized requests.
  - Forward Authorization header consistently using normalized headers.
  - Cloudinary: Only the latest request updates state to avoid race conditions; ignore AbortError; correct loading vs. loadingMore; clear in-flight cursor only for the matching request.

- **Refactors**
  - SecurityUtils: Centralized origin normalization (scheme://host[:port]) and deduplication for precise Origin and Referer checks.

<sup>Written for commit 632e777a77c358cffd928892788c8c35e1586fa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

