### PR TITLE
fix: use lazy initializer in SidebarMenuSkeleton useState

### DIFF
--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -640,7 +640,7 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean;
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  const [width] = React.useState(`${Math.floor(seededRandom() * 40) + 50}%`);
+  const [width] = React.useState(() => `${Math.floor(seededRandom() * 40) + 50}%`);
 
   return (
     <div

--- a/docs/security/dependency-supply-chain-security.md
+++ b/docs/security/dependency-supply-chain-security.md
@@ -22,7 +22,7 @@ We use **GitHub Dependabot** to automate our dependency management. Dependabot a
 
 ### Key Configuration Decisions
 
-- **Daily Monitoring**: We check for updates every morning (`09:00 Africa/Nairobi`) to ensure we are alerted to zero-day vulnerabilities as quickly as possible.
+- **Weekly Monitoring**: We check for updates every week to ensure we are alerted to vulnerabilities in a timely manner.
 - **Dependency Grouping**: To maintain a stable build, we group related packages (e.g., `react` and `@types/react`) so they are updated together, reducing the risk of version mismatch errors.
 - **PR Limit**: We limit the number of open Dependabot Pull Requests to `10` to prevent "alert fatigue" and ensure that each security update is reviewed carefully.
 - **Designated Reviewers**: All security PRs are automatically assigned to senior developers for immediate review.
@@ -35,7 +35,7 @@ The Dependabot configuration is located at:
 ### Relevant Sections Explained
 
 - `package-ecosystem: "npm"`: Monitors our JavaScript/TypeScript dependencies.
-- `interval: "daily"`: The frequency of security checks.
+- `interval: "weekly"`: The frequency of security checks.
 - `groups`: Logical groupings developed to ensure that core React and toolchain components remain in sync during updates.
 - `ignore`: Configuration to skip specific version ranges (e.g., blocking major version upgrades that contain breaking changes until the team is ready).
 


### PR DESCRIPTION
## What does this PR do?

Fixes a stale closure / unnecessary re-computation in `SidebarMenuSkeleton`
by wrapping the `seededRandom()` call in a lazy initializer, and updates
documentation to reflect the Dependabot weekly schedule change.

## Linked issue

<!-- No issue — trivial fix + docs correction -->

## Type of change

- [x] `fix` — bug fix
- [x] `docs` — documentation only

## What changed?

- Wrapped `seededRandom()` in a lazy initializer `() => ...` inside
  `SidebarMenuSkeleton`'s `React.useState` to ensure the random width is
  computed only once on mount, not on every render
- Updated `docs/security/dependency-supply-chain-security.md` to correctly
  document Dependabot's schedule as **weekly** (changed in #316), replacing
  the outdated "daily" references

## Screenshots

N/A — no visual change

## How was this tested?

- Ran `npm run format` — all files pass Prettier formatting
- Ran `npm run build` — build passes with no TypeScript or lint errors
- Verified `SidebarMenuSkeleton` renders correctly with consistent width

## Pre-submission checklist

### Required for all PRs

- [x] `npm run format` has been run to format all code
- [x] `npm run build` passes with no errors
- [x] `npm run lint` passes with no new warnings
- [x] `npm run typecheck` passes with no TypeScript errors
- [x] No `console.log`, commented-out code, or debug artifacts left in
- [ ] Branch is up to date with `main`
- [x] PR title follows Conventional Commits format

## Notes for reviewers

The bulk of "modified" files in `git status` are LF→CRLF line-ending
changes introduced by Prettier on Windows. These carry no logic changes.
Consider adding a `.gitattributes` with `* text=auto eol=lf` to normalise
line endings across platforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/322)
<!-- Reviewable:end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a lazy initializer in `React.useState` to compute `SidebarMenuSkeleton`’s seeded width once per mount, preventing re-computation. Also updates security docs to reflect Dependabot’s weekly schedule.

<sup>Written for commit 1c40d03c2a6a1b725b8ddf2b3c89201fcc397f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

