### PR TITLE
ci: fix github workflows and add release automation

### DIFF
--- a/.github/actions/cache-vite-npm/action.yml
+++ b/.github/actions/cache-vite-npm/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js (with npm cache)
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.2.0
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: "npm"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,40 @@
+# File- and branch-based label rules.
+# Title-based labeling is handled by pr-auto-label.yml (github-script step).
+
+feature:
+  - head-branch: ["^feat", "^feature"]
+
+bug:
+  - head-branch: ["^fix", "^bug"]
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ["docs/**", "*.md", "CONTENT_GUIDE.md"]
+  - head-branch: ["^docs", "^doc"]
+
+ci/cd:
+  - changed-files:
+      - any-glob-to-any-file: [".github/workflows/**", ".github/actions/**"]
+
+dependencies:
+  - head-branch: ["^dependabot"]
+  - changed-files:
+      - any-glob-to-any-file: ["package.json", "package-lock.json"]
+
+refactor:
+  - head-branch: ["^refactor", "^chore"]
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.test.ts"
+          - "**/*.test.tsx"
+          - "**/*.spec.ts"
+          - "**/__tests__/**"
+
+security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/security*"
+          - "**/*security*"
+          - "security-policy.json"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,6 +35,7 @@ tests:
 security:
   - changed-files:
       - any-glob-to-any-file:
+          - "**/security/**"
           - "**/security*"
           - "**/*security*"
           - "security-policy.json"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,5 @@ security:
   - changed-files:
       - any-glob-to-any-file:
           - "**/security/**"
-          - "**/security-*"
-          - "**/*.security.*"
+          - "**/*security*"
           - "security-policy.json"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,6 @@ security:
   - changed-files:
       - any-glob-to-any-file:
           - "**/security/**"
-          - "**/security*"
-          - "**/*security*"
+          - "**/security-*"
+          - "**/*.security.*"
           - "security-policy.json"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@
 #
 name: "CodeQL Advanced"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main"]
@@ -29,14 +33,7 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
       contents: read
 
     strategy:

--- a/.github/workflows/node-engine-update.yml
+++ b/.github/workflows/node-engine-update.yml
@@ -21,15 +21,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: ./.github/actions/cache-vite-npm
         with:
           node-version: 20
-          cache: "npm"
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund --ignore-scripts

--- a/.github/workflows/node-engine-update.yml
+++ b/.github/workflows/node-engine-update.yml
@@ -26,9 +26,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: ./.github/actions/cache-vite-npm
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 20
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund --ignore-scripts

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -30,30 +30,51 @@ jobs:
             const currentLabels = context.payload.pull_request.labels.map(l => l.name);
 
             const titleRules = [
-              { regex: /^feat(\(.*?\))?:\s/, label: 'feature' },
-              { regex: /^fix(\(.*?\))?:\s/, label: 'bug' },
-              { regex: /^docs(\(.*?\))?:\s/, label: 'documentation' },
-              { regex: /^refactor(\(.*?\))?:\s/, label: 'refactor' },
-              { regex: /^ci(\(.*?\))?:\s/, label: 'ci/cd' },
-              { regex: /^build(\(deps(?:-dev)?\))?:\s/, label: 'dependencies' },
-              { regex: /^test(\(.*?\))?:\s/, label: 'tests' },
-              { regex: /^security(\(.*?\))?:\s/, label: 'security' },
+              { regex: /^feat(\(.*?\))?!?:\s/, label: 'feature' },
+              { regex: /^fix(\(.*?\))?!?:\s/, label: 'bug' },
+              { regex: /^docs(\(.*?\))?!?:\s/, label: 'documentation' },
+              { regex: /^refactor(\(.*?\))?!?:\s/, label: 'refactor' },
+              { regex: /^ci(\(.*?\))?!?:\s/, label: 'ci/cd' },
+              { regex: /^build(\(deps(?:-dev)?\))?!?:\s/, label: 'dependencies' },
+              { regex: /^test(\(.*?\))?!?:\s/, label: 'tests' },
+              { regex: /^security(\(.*?\))?!?:\s/, label: 'security' },
             ];
 
+            // All labels this workflow manages (title-rule labels + breaking-change).
+            const managedLabels = [...titleRules.map(r => r.label), 'breaking-change'];
+
             const toAdd = [];
+            const toRemove = [];
 
             for (const rule of titleRules) {
-              if (rule.regex.test(title) && !currentLabels.includes(rule.label)) {
+              const matches = rule.regex.test(title);
+              if (matches && !currentLabels.includes(rule.label)) {
                 toAdd.push(rule.label);
+              } else if (!matches && currentLabels.includes(rule.label)) {
+                toRemove.push(rule.label);
               }
             }
 
-            if (/\)?!:/.test(title) && !currentLabels.includes('breaking-change')) {
+            const isBreaking = /\)?!:/.test(title);
+            if (isBreaking && !currentLabels.includes('breaking-change')) {
               toAdd.push('breaking-change');
+            } else if (!isBreaking && currentLabels.includes('breaking-change')) {
+              toRemove.push('breaking-change');
             }
 
             if (toAdd.length > 0) {
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: number, labels: toAdd
               });
+            }
+
+            for (const label of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: number, name: label
+                });
+              } catch (e) {
+                // Label may have already been removed manually — ignore 404s.
+                if (e.status !== 404) throw e;
+              }
             }

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -34,14 +34,14 @@ jobs:
               { regex: /^fix(\(.*?\))?!?:\s/, label: 'bug' },
               { regex: /^docs(\(.*?\))?!?:\s/, label: 'documentation' },
               { regex: /^refactor(\(.*?\))?!?:\s/, label: 'refactor' },
+              { regex: /^chore(\(.*?\))?!?:\s/, label: 'refactor' },
               { regex: /^ci(\(.*?\))?!?:\s/, label: 'ci/cd' },
               { regex: /^build(\(deps(?:-dev)?\))?!?:\s/, label: 'dependencies' },
               { regex: /^test(\(.*?\))?!?:\s/, label: 'tests' },
               { regex: /^security(\(.*?\))?!?:\s/, label: 'security' },
             ];
 
-            // All labels this workflow manages (title-rule labels + breaking-change).
-            const managedLabels = [...titleRules.map(r => r.label), 'breaking-change'];
+
 
             const toAdd = [];
             const toRemove = [];

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -2,7 +2,7 @@ name: PR Auto Label
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
@@ -30,21 +30,20 @@ jobs:
             const currentLabels = context.payload.pull_request.labels.map(l => l.name);
 
             const titleRules = [
-              { patterns: ['feat:'], label: 'feature' },
-              { patterns: ['fix:'], label: 'bug' },
-              { patterns: ['docs:'], label: 'documentation' },
-              { patterns: ['refactor:'], label: 'refactor' },
-              { patterns: ['ci:'], label: 'ci/cd' },
-              { patterns: ['build(deps):', 'build(deps-dev):', 'build:'], label: 'dependencies' },
-              { patterns: ['test:'], label: 'tests' },
-              { patterns: ['security:'], label: 'security' },
+              { regex: /^feat(\(.*?\))?:\s/, label: 'feature' },
+              { regex: /^fix(\(.*?\))?:\s/, label: 'bug' },
+              { regex: /^docs(\(.*?\))?:\s/, label: 'documentation' },
+              { regex: /^refactor(\(.*?\))?:\s/, label: 'refactor' },
+              { regex: /^ci(\(.*?\))?:\s/, label: 'ci/cd' },
+              { regex: /^build(\(deps(?:-dev)?\))?:\s/, label: 'dependencies' },
+              { regex: /^test(\(.*?\))?:\s/, label: 'tests' },
+              { regex: /^security(\(.*?\))?:\s/, label: 'security' },
             ];
 
             const toAdd = [];
 
             for (const rule of titleRules) {
-              const matched = rule.patterns.some(p => title.startsWith(p));
-              if (matched && !currentLabels.includes(rule.label)) {
+              if (rule.regex.test(title) && !currentLabels.includes(rule.label)) {
                 toAdd.push(rule.label);
               }
             }

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,60 @@
+name: PR Auto Label
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Apply Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: File- and branch-based labels
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+
+      - name: Title-based labels
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const title = context.payload.pull_request.title.toLowerCase();
+            const currentLabels = context.payload.pull_request.labels.map(l => l.name);
+
+            const titleRules = [
+              { patterns: ['feat:'], label: 'feature' },
+              { patterns: ['fix:'], label: 'bug' },
+              { patterns: ['docs:'], label: 'documentation' },
+              { patterns: ['refactor:'], label: 'refactor' },
+              { patterns: ['ci:'], label: 'ci/cd' },
+              { patterns: ['build(deps):', 'build(deps-dev):', 'build:'], label: 'dependencies' },
+              { patterns: ['test:'], label: 'tests' },
+              { patterns: ['security:'], label: 'security' },
+            ];
+
+            const toAdd = [];
+
+            for (const rule of titleRules) {
+              const matched = rule.patterns.some(p => title.startsWith(p));
+              if (matched && !currentLabels.includes(rule.label)) {
+                toAdd.push(rule.label);
+              }
+            }
+
+            if (/\)?!:/.test(title) && !currentLabels.includes('breaking-change')) {
+              toAdd.push('breaking-change');
+            }
+
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: number, labels: toAdd
+              });
+            }

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -30,6 +30,9 @@ jobs:
             test
             security
           requireScope: false
+          subjectPattern: '^[a-z].+'
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
           validateSingleCommit: false
           wip: true
           ignoreLabels: |

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -30,7 +30,7 @@ jobs:
             test
             security
           requireScope: false
-          subjectPattern: '^[a-z].+'
+          subjectPattern: "^[a-z].+"
           subjectPatternError: |
             The subject "{subject}" must start with a lowercase letter.
           validateSingleCommit: false

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -2,7 +2,7 @@ name: PR Title Lint
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   pull-requests: write
@@ -30,8 +30,6 @@ jobs:
             test
             security
           requireScope: false
-          subjectPatternError: |
-            The subject "{subject}" must start with a lowercase letter.
           validateSingleCommit: false
           wip: true
           ignoreLabels: |

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -30,7 +30,7 @@ jobs:
             test
             security
           requireScope: false
-          subjectPattern: "^[a-z].+"
+          subjectPattern: "^[a-z].*"
           subjectPatternError: |
             The subject "{subject}" must start with a lowercase letter.
           validateSingleCommit: false

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,84 @@
+name: PR Title Lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  validate:
+    name: Validate Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint PR Title
+        id: lint
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            ci
+            build
+            test
+            security
+          requireScope: false
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
+          validateSingleCommit: false
+          wip: true
+          ignoreLabels: |
+            automated
+            dependencies
+
+      - name: Post help comment on failure
+        if: failure() && steps.lint.outcome == 'failure'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title;
+            const body = [
+              'Thanks for opening this PR! The title doesn\'t match our required format.',
+              '',
+              '**PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/):**',
+              '',
+              '| Type | Example |',
+              '|------|---------|',
+              '| `feat:` | `feat: add speaker search filter` |',
+              '| `fix:` | `fix: resolve mobile nav overflow` |',
+              '| `chore:` | `chore: update dependencies` |',
+              '| `docs:` | `docs: update contributing guide` |',
+              '| `refactor:` | `refactor: extract SpeakerCard component` |',
+              '| `ci:` | `ci: speed up build workflow` |',
+              '| `build:` | `build: bump vite to v6` |',
+              '| `test:` | `test: add SpeakerCard unit tests` |',
+              '| `security:` | `security: fix XSS in search input` |',
+              '',
+              '**Current title:** `' + title + '`',
+              '',
+              '**Tip:** You can edit the title directly in this PR\'s title field above.',
+              'No need to close and reopen — just edit and the check will re-run.'
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.issue
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Conventional Commits')
+            );
+
+            if (!existing) {
+              await github.rest.issues.createComment({
+                ...context.issue,
+                body: body
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
-      new_version: ${{ steps.update-version.outputs.new_version }}
+      new_version: ${{ steps.update-version.outputs.new_version || steps.update-version-recovery.outputs.new_version }}
 
     steps:
       - name: Checkout repository
@@ -78,18 +78,21 @@ jobs:
               const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha
               });
-              const match = prs.find(p => p.head.ref === 'pre-staging' && p.merged_at);
+              const match = prs.find(p =>
+                p.head.ref === 'pre-staging' &&
+                p.base.ref === 'main' &&
+                p.merged_at
+              );
               if (match) {
                 core.setOutput('pr_number', String(match.number));
                 core.setOutput('pr_title', match.title);
                 return 'true';
               }
-            } catch { /* fallback */ }
+            } catch (e) {
+              core.warning('Failed to query PRs: ' + e.message);
+            }
 
-            const msg = (commit.data.commit.message || '').toLowerCase();
-            if (msg.includes('pre-staging')) return 'true';
-
-            core.notice('Not a pre-staging merge — skipping');
+            core.notice('Not a pre-staging → main merge — skipping');
             return 'false';
 
       - name: Fetch tags
@@ -144,10 +147,12 @@ jobs:
 
           if [ "$BUMP" = "manual" ] && [ -n "$MANUAL_VER" ]; then
             # Validate manual version is a valid semver
+            # Only accept strict numeric x.y.z — prerelease/build suffixes
+            # would break the IFS-based integer arithmetic in the bump step.
             node -e "
               const v = process.argv[1];
-              if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(v)) {
-                console.error('Invalid semver: ' + v);
+              if (!/^\d+\.\d+\.\d+$/.test(v)) {
+                console.error('Invalid version: ' + v + ' (must be numeric x.y.z)');
                 process.exit(1);
               }
             " "${MANUAL_VER}"
@@ -163,16 +168,34 @@ jobs:
             patch) echo "new_version=${P[0]}.${P[1]}.$((P[2]+1))" ;;
           esac >> $GITHUB_OUTPUT
 
-      - name: Guard — reject duplicate tag
+      - name: Guard — check for existing tag & release
         id: guard
         if: steps.verify-merge.outputs.result == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           V="${{ steps.semver.outputs.new_version }}"
+          TAG_EXISTS=false
+          RELEASE_EXISTS=false
+
           if git tag -l "v${V}" | grep -q .; then
-            echo "Tag v${V} already exists — skipping."
+            TAG_EXISTS=true
+          fi
+
+          if gh release view "v${V}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            RELEASE_EXISTS=true
+          fi
+
+          if [ "$TAG_EXISTS" = "true" ] && [ "$RELEASE_EXISTS" = "true" ]; then
+            echo "Tag and release v${V} both exist — skipping."
             echo "skip=true" >> $GITHUB_OUTPUT
+          elif [ "$TAG_EXISTS" = "true" ] && [ "$RELEASE_EXISTS" = "false" ]; then
+            echo "::warning::Tag v${V} exists but release is missing — will create release."
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "tag_only=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
+            echo "tag_only=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Guard — reject rollback (older than latest tag)
@@ -189,7 +212,7 @@ jobs:
 
       - name: Bump package.json & create tag
         id: update-version
-        if: steps.guard.outputs.skip == 'false'
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.tag_only != 'true'
         run: |
           V="${{ steps.semver.outputs.new_version }}"
           node -e "
@@ -205,6 +228,14 @@ jobs:
           git tag "v${V}"
           git push origin "v${V}"
           echo "new_version=${V}" >> $GITHUB_OUTPUT
+
+      # When recovering from a partial run (tag exists, release missing),
+      # propagate new_version so changelog + release steps can proceed.
+      - name: Propagate version (tag-only recovery)
+        id: update-version-recovery
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.tag_only == 'true'
+        run: |
+          echo "new_version=${{ steps.semver.outputs.new_version }}" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,312 @@
+name: Release Automation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Force version bump (major, minor, patch)"
+        required: false
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+      version:
+        description: "Explicit version (e.g. 2.0.0). Overrides auto-detection."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.update-version.outputs.new_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies (minimal)
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Detect pre-staging → main merge
+        id: verify-merge
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            if (context.eventName === 'workflow_dispatch') {
+              core.notice('Manual release trigger');
+              return 'true';
+            }
+
+            const commit = await github.rest.repos.getCommit({
+              owner: context.repo.owner, repo: context.repo.repo, ref: context.sha
+            });
+
+            if (commit.data.parents.length < 2) {
+              core.notice('Not a merge commit — skipping');
+              return 'false';
+            }
+
+            try {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha
+              });
+              const match = prs.find(p => p.head.ref === 'pre-staging' && p.merged_at);
+              if (match) {
+                core.setOutput('pr_number', String(match.number));
+                core.setOutput('pr_title', match.title);
+                return 'true';
+              }
+            } catch { /* fallback */ }
+
+            const msg = (commit.data.commit.message || '').toLowerCase();
+            if (msg.includes('pre-staging')) return 'true';
+
+            core.notice('Not a pre-staging merge — skipping');
+            return 'false';
+
+      - name: Fetch tags
+        if: steps.verify-merge.outputs.result == 'true'
+        run: git fetch --tags --force
+
+      - name: Determine version bump
+        id: bump
+        if: steps.verify-merge.outputs.result == 'true'
+        run: |
+          LAST_TAG=$(git tag --sort=-version:refname | head -1)
+          echo "last_tag=${LAST_TAG:-none}" >> $GITHUB_OUTPUT
+
+          if [ -z "$LAST_TAG" ]; then
+            CURRENT="0.0.0"; RANGE="HEAD"
+          else
+            CURRENT="${LAST_TAG#v}"; RANGE="${LAST_TAG}..HEAD"
+          fi
+          echo "current_version=${CURRENT}" >> $GITHUB_OUTPUT
+
+          # Manual override takes priority
+          MANUAL_BUMP="${{ github.event.inputs.bump }}"
+          MANUAL_VER="${{ github.event.inputs.version }}"
+
+          if [ -n "$MANUAL_VER" ]; then
+            echo "bump=manual" >> $GITHUB_OUTPUT
+            echo "manual_version=${MANUAL_VER}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ "$MANUAL_BUMP" != "" ] && [ "$MANUAL_BUMP" != "auto" ]; then
+            echo "bump=${MANUAL_BUMP}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Auto-detect from commit history
+          BUMP="patch"
+          if git log "$RANGE" --format="%s %b" | grep -qE "BREAKING CHANGE|!: ?"; then
+            BUMP="major"
+          elif git log "$RANGE" --format="%s" | grep -qE "^feat(\(.*\))?:"; then
+            BUMP="minor"
+          fi
+          echo "bump=${BUMP}" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
+        id: semver
+        if: steps.verify-merge.outputs.result == 'true'
+        run: |
+          BUMP="${{ steps.bump.outputs.bump }}"
+          MANUAL_VER="${{ steps.bump.outputs.manual_version }}"
+
+          if [ "$BUMP" = "manual" ] && [ -n "$MANUAL_VER" ]; then
+            echo "new_version=${MANUAL_VER}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT="${{ steps.bump.outputs.current_version }}"
+          IFS='.' read -ra P <<< "$CURRENT"
+          case "$BUMP" in
+            major) echo "new_version=$((P[0]+1)).0.0" ;;
+            minor) echo "new_version=${P[0]}.$((P[1]+1)).0" ;;
+            patch) echo "new_version=${P[0]}.${P[1]}.$((P[2]+1))" ;;
+          esac >> $GITHUB_OUTPUT
+
+      - name: Guard — reject duplicate tag
+        id: guard
+        if: steps.verify-merge.outputs.result == 'true'
+        run: |
+          V="${{ steps.semver.outputs.new_version }}"
+          if git tag -l "v${V}" | grep -q .; then
+            echo "Tag v${V} already exists — skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Guard — reject rollback (older than latest tag)
+        if: steps.guard.outputs.skip == 'false' && steps.bump.outputs.last_tag != 'none'
+        run: |
+          V="${{ steps.semver.outputs.new_version }}"
+          LATEST="${{ steps.bump.outputs.last_tag }}"
+          LATEST="${LATEST#v}"
+          LOWEST=$(printf '%s\n' "$V" "$LATEST" | sort -V | head -1)
+          if [ "$LOWEST" = "$V" ] && [ "$V" != "$LATEST" ]; then
+            echo "::warning::New version v${V} is older than v${LATEST}. Possible rollback."
+            echo "Proceeding anyway — use workflow_dispatch with explicit version to override."
+          fi
+
+      - name: Bump package.json & create tag
+        id: update-version
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          V="${{ steps.semver.outputs.new_version }}"
+          node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8'));
+            pkg.version = '${V}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: release v${V}"
+          git push origin HEAD
+          git tag "v${V}"
+          git push origin "v${V}"
+          echo "new_version=${V}" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        id: changelog
+        if: steps.guard.outputs.skip == 'false'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          NEW_VERSION: ${{ steps.semver.outputs.new_version }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const newVersion = process.env.NEW_VERSION;
+
+            let range = 'HEAD';
+            try {
+              const t = require('child_process')
+                .execSync('git tag --sort=-version:refname | head -1', { encoding: 'utf8' }).trim();
+              if (t) range = `${t}..HEAD`;
+            } catch {}
+
+            const categories = {
+              'Breaking Changes': [],
+              'Features': [],
+              'Bug Fixes': [],
+              'Documentation': [],
+              'Refactoring': [],
+              'CI/CD': [],
+              'Dependencies': [],
+              'Other': []
+            };
+
+            let raw = '';
+            try {
+              raw = require('child_process')
+                .execSync(`git log ${range} --merges --format="%s|||%b"`, {
+                  encoding: 'utf8', maxBuffer: 10 * 1024 * 1024
+                }).trim();
+            } catch {}
+
+            for (const line of raw.split('\n').filter(Boolean)) {
+              const [s] = line.split('|||');
+              if (!s || /bump version|release \d/i.test(s)) continue;
+
+              const t = s.trim();
+              const strip = (re) => t.replace(re, '').replace(/^[a-z]/, c => c.toUpperCase()).trim();
+
+              if (t.includes('!:')) {
+                categories['Breaking Changes'].push(strip(/^.+?!:\s*/));
+              } else if (/^feat/.test(t)) {
+                categories['Features'].push(strip(/^feat(\(.*?\))?:\s*/));
+              } else if (/^fix/.test(t)) {
+                categories['Bug Fixes'].push(strip(/^fix(\(.*?\))?:\s*/));
+              } else if (/^docs/.test(t)) {
+                categories['Documentation'].push(strip(/^docs(\(.*?\))?:\s*/));
+              } else if (/^refactor/.test(t)) {
+                categories['Refactoring'].push(strip(/^refactor(\(.*?\))?:\s*/));
+              } else if (/^ci/.test(t)) {
+                categories['CI/CD'].push(strip(/^ci(\(.*?\))?:\s*/));
+              } else if (/^build/.test(t)) {
+                // Group dependabot bumps under single line
+                const dep = t.replace(/^build\(deps(?:-dev)?\):\s*/i, '')
+                             .replace(/^build:\s*/i, '')
+                             .replace(/^[a-z]/i, c => c.toUpperCase());
+                categories['Dependencies'].push(dep);
+              } else {
+                categories['Other'].push(t);
+              }
+            }
+
+            const date = new Date().toISOString().split('T')[0];
+            let md = `## v${newVersion} (${date})\n\n`;
+
+            for (const [section, items] of Object.entries(categories)) {
+              if (items.length) {
+                md += `### ${section}\n`;
+                for (const item of items) md += `- ${item}\n`;
+                md += '\n';
+              }
+            }
+
+            if (!md.includes('- ')) md += '- No significant changes captured for this release.\n';
+
+            // Write CHANGELOG.md
+            const fs = require('fs');
+            const header = '# Changelog\n\n';
+            let existing = '';
+            try { existing = fs.readFileSync('CHANGELOG.md', 'utf8'); } catch {}
+            if (!existing) existing = header + 'All notable changes to this project will be documented in this file.\n\n';
+            const separator = existing.startsWith(header) ? '' : (header + '\n');
+            fs.writeFileSync('CHANGELOG.md', separator + md + '\n---\n\n' + existing.replace(/^# Changelog\n\n?/, ''));
+
+            // Write release notes to file (avoids shell escaping issues)
+            fs.writeFileSync('.release-notes.md', md);
+
+      - name: Commit CHANGELOG.md
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No CHANGELOG changes"
+          else
+            git commit -m "chore: update CHANGELOG for v${{ steps.semver.outputs.new_version }}"
+            git push origin main
+          fi
+
+      - name: Create GitHub Release
+        if: steps.guard.outputs.skip == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.semver.outputs.new_version }}" \
+            --repo "${{ github.repository }}" \
+            --title "v${{ steps.semver.outputs.new_version }}" \
+            --notes-file .release-notes.md \
+            --target "${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
             CURRENT="${LAST_TAG#v}"; RANGE="${LAST_TAG}..HEAD"
           fi
           echo "current_version=${CURRENT}" >> $GITHUB_OUTPUT
+          echo "changelog_range=${RANGE}" >> $GITHUB_OUTPUT
 
           # Manual override takes priority
           MANUAL_BUMP="${{ github.event.inputs.bump }}"
@@ -134,7 +135,7 @@ jobs:
           fi
           echo "bump=${BUMP}" >> $GITHUB_OUTPUT
 
-      - name: Calculate new version
+      - name: Validate and calculate new version
         id: semver
         if: steps.verify-merge.outputs.result == 'true'
         run: |
@@ -142,6 +143,14 @@ jobs:
           MANUAL_VER="${{ steps.bump.outputs.manual_version }}"
 
           if [ "$BUMP" = "manual" ] && [ -n "$MANUAL_VER" ]; then
+            # Validate manual version is a valid semver
+            node -e "
+              const v = process.argv[1];
+              if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(v)) {
+                console.error('Invalid semver: ' + v);
+                process.exit(1);
+              }
+            " "${MANUAL_VER}"
             echo "new_version=${MANUAL_VER}" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -200,20 +209,18 @@ jobs:
       - name: Generate changelog
         id: changelog
         if: steps.guard.outputs.skip == 'false'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           NEW_VERSION: ${{ steps.semver.outputs.new_version }}
+          CHANGELOG_RANGE: ${{ steps.bump.outputs.changelog_range }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const newVersion = process.env.NEW_VERSION;
 
-            let range = 'HEAD';
-            try {
-              const t = require('child_process')
-                .execSync('git tag --sort=-version:refname | head -1', { encoding: 'utf8' }).trim();
-              if (t) range = `${t}..HEAD`;
-            } catch {}
+            // Use the range captured before creating the new tag,
+            // so we get the commits between the previous tag and HEAD.
+            const range = process.env.CHANGELOG_RANGE || 'HEAD';
 
             const categories = {
               'Breaking Changes': [],

--- a/.github/workflows/validate-security-policy.yml
+++ b/.github/workflows/validate-security-policy.yml
@@ -1,10 +1,14 @@
 name: Validate Security Policy Generation
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
-    branches: [main, pre-staging, production, staging]
+    branches: [main, pre-staging]
   pull_request:
-    branches: [main, pre-staging, production, staging]
+    branches: [main, pre-staging]
 
 jobs:
   validate-policy:
@@ -14,20 +18,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 20
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Scan dependencies
-        if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@v4
 
       - name: Lint lockfile (registry/https)
         run: |


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub workflow issues and adds pull request validation, auto-labeling, and release automation.

## Linked issue

No issue — this is a workflow correction and release automation setup.

## Type of change

- [ ] `feat` — new feature or component
- [ ] `fix` — bug fix
- [ ] `style` — UI / visual change (no logic change)
- [ ] `content` — data file update (speakers, FAQs, sponsors, etc.)
- [ ] `refactor` — code restructuring (no behaviour change)
- [ ] `docs` — documentation only
- [x] `chore` — dependency update, config change, build tweak

## What changed?

- **Workflow Version Pinned & Caching**: Pinned GitHub action checkout and node setup references to secure hashes; updated the `node-engine-update` workflow to leverage the custom cached `cache-vite-npm` composite action.
- **Concurrency & Scopes**: Added workflow concurrency definitions to automatically cancel outdated runs when new commits are pushed, and refined target branches in the security policy workflow to `main` and `pre-staging`.
- **PR Auto Labeler**: Added `.github/workflows/pr-auto-label.yml` and `.github/labeler.yml` to automatically classify incoming pull requests based on changed files, branches, and titles.
- **PR Title Linter**: Added `.github/workflows/pr-title-lint.yml` to enforce Conventional Commits compliance for pull request titles.
- **Release Automation**: Introduced `.github/workflows/release.yml` to automate semantic version bumping, CHANGELOG updates, tag creation, and GitHub Releases on merges from `pre-staging` to `main`.
- **Formatting**: Corrected line endings and formatting issues across 15 files via `npm run format` to ensure the project passes the strict validation steps during builds.

## Screenshots

### Before

N/A — no visual change

### After

N/A — no visual change

### Breakpoints tested

- [ ] Mobile — 375px
- [ ] Tablet — 768px
- [ ] Desktop — 1280px
- [ ] Wide — 1536px+

## How was this tested?

- Ran `npm run format` locally to verify formatting issues are resolved.
- Ran `npm run build` locally which successfully passed all check stages (`lint`, `typecheck`, and `format:check`), generated the security headers, built the site bundles, and generated the sitemap.

## Pre-submission checklist

### Required for all PRs

- [x] `npm run format` has been run to format all code
- [x] `npm run build` passes with no errors
- [x] `npm run lint` passes with no new warnings
- [x] `npm run typecheck` passes with no TypeScript errors
- [x] No `console.log`, commented-out code, or debug artifacts left in
- [x] Branch is up to date with `main`
- [x] PR title follows Conventional Commits format (e.g. `feat: add speaker search filter`)

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/324)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes and hardens CI workflows, adds PR auto-labeling and Conventional Commits title linting, and automates semantic versioning and GitHub Releases when `pre-staging` merges into `main` or via manual dispatch.

- **New Features**
  - Automated releases via `release.yml`: triggers on `pre-staging` → `main` merges or manual dispatch; supports auto/forced bumps or explicit versions; updates `package.json` and `CHANGELOG.md`, tags, and creates a GitHub Release with notes and guard checks.
  - PR auto-labeling using `.github/labeler.yml` (branch/file rules) plus title rules via `actions/github-script`; adds/removes labels based on title and adds `breaking-change` on `!`.
  - PR title linter via `amannn/action-semantic-pull-request`; enforces Conventional Commits and posts a help comment on failure.

- **Refactors**
  - Pin `actions/checkout` and `actions/setup-node` to SHAs across workflows (including `cache-vite-npm` and `node-engine-update`).
  - Add concurrency groups and tighten permissions (e.g., CodeQL and security policy); limit security policy checks to `main` and `pre-staging` and remove dependency review.

<sup>Written for commit 7eebf382528d488f33cc36462bf77fb845f0728f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced GitHub Actions workflows for improved CI/CD automation
  * Added automated pull request validation and labeling
  * Implemented automated release workflow with semantic versioning
  * Updated workflow security permissions and concurrency controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->