### PR TITLE
fix: harden staging deploy workflow and php proxy handling

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,8 +1,5 @@
 name: Deploy to cPanel (Staging)
 
-permissions:
-  contents: read
-
 # One deploy at a time — do NOT cancel in-progress staging deploys
 concurrency:
   group: deploy-staging
@@ -32,6 +29,8 @@ jobs:
   build:
     name: Build (Staging Mode)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       # 1. Check out the code

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,4 +1,9 @@
+# Workflow name
 name: Deploy to cPanel (Staging)
+
+# Minimum GITHUB_TOKEN permissions — top-level so all jobs inherit this by default
+permissions:
+  contents: read
 
 # One deploy at a time — do NOT cancel in-progress staging deploys
 concurrency:

--- a/client/public/api/api-middleware.php
+++ b/client/public/api/api-middleware.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Shared API Proxy Middleware
+ *
+ * Consolidates common middleware (CORS, preflight, rate limiting,
+ * authentication, method allowlist) to eliminate duplication
+ * across API proxy endpoints.
+ */
+
+require_once __DIR__ . '/config-loader.php';
+require_once __DIR__ . '/security-utils.php';
+
+const PROXY_ALLOWED_ORIGINS = [
+    'https://nairobidevops.org',
+    'https://www.nairobidevops.org',
+];
+
+const PROXY_JSON_FLAGS = JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
+
+function proxyJsonResponse($data, $statusCode = 200) {
+    http_response_code($statusCode);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($data, PROXY_JSON_FLAGS);
+    exit;
+}
+
+function proxyJsonError($message, $statusCode) {
+    proxyJsonResponse(['error' => $message], $statusCode);
+}
+
+function proxyGetHeaders() {
+    if (function_exists('getallheaders')) {
+        return getallheaders();
+    }
+    if (function_exists('apache_request_headers')) {
+        return apache_request_headers();
+    }
+    return [];
+}
+
+function proxyRunMiddleware($allowedMethods = ['GET', 'POST', 'OPTIONS']) {
+    header('X-Content-Type-Options: nosniff');
+
+    $validOrigin = SecurityUtils::validateOrigin(PROXY_ALLOWED_ORIGINS);
+    if (!empty($validOrigin)) {
+        header('Access-Control-Allow-Origin: ' . $validOrigin);
+        header('Vary: Origin');
+    }
+
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+    if ($method === 'OPTIONS') {
+        if (!empty($validOrigin)) {
+            header('Access-Control-Allow-Methods: ' . implode(', ', $allowedMethods));
+            header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-Proxy-Token');
+            header('Access-Control-Max-Age: 86400');
+        }
+        http_response_code(204);
+        exit;
+    }
+
+    $cacheRootDir = getProxyCacheDir();
+    if (!SecurityUtils::checkRateLimit($cacheRootDir . '/rate_limits', 30, 60)) {
+        proxyJsonError('Too Many Requests', 429);
+    }
+
+    $headersLower = array_change_key_case(proxyGetHeaders(), CASE_LOWER);
+
+    $authHeaderToken = $headersLower['x-proxy-token'] ?? '';
+    if (preg_match('/Bearer\s+(.*)$/i', $authHeaderToken, $matches)) {
+        $authHeaderToken = trim($matches[1]);
+    }
+
+    $expectedToken = defined('PROXY_API_TOKEN') ? PROXY_API_TOKEN : getenv('PROXY_API_TOKEN');
+    $isAjax = strtolower($headersLower['x-requested-with'] ?? '') === 'xmlhttprequest';
+    $isAuthenticated = SecurityUtils::validateToken($authHeaderToken, $expectedToken);
+
+    if (!$isAuthenticated && !(!empty($validOrigin) && $isAjax)) {
+        proxyJsonError('Unauthorized', 401);
+    }
+
+    if (!in_array($method, $allowedMethods, true)) {
+        header('Allow: ' . implode(', ', $allowedMethods));
+        proxyJsonError('Method Not Allowed', 405);
+    }
+
+    return [
+        'method' => $method,
+        'validOrigin' => $validOrigin,
+        'cacheRootDir' => $cacheRootDir,
+        'headersLower' => $headersLower,
+    ];
+}
+
+function proxyServeCache($cacheFile, $cacheTTL, $contentType = 'application/json; charset=utf-8') {
+    if (file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTTL)) {
+        $data = file_get_contents($cacheFile);
+        if ($data) {
+            header('Content-Type: ' . $contentType);
+            header('X-Cache: HIT');
+            echo $data;
+            return true;
+        }
+    }
+    return false;
+}
+
+function proxyWriteCache($cacheFile, $data) {
+    if (!is_dir(dirname($cacheFile))) {
+        mkdir(dirname($cacheFile), 0700, true);
+    }
+    file_put_contents($cacheFile . '.tmp', $data, LOCK_EX);
+    rename($cacheFile . '.tmp', $cacheFile);
+}

--- a/client/public/api/api-middleware.php
+++ b/client/public/api/api-middleware.php
@@ -99,10 +99,9 @@ function proxyServeCache($cacheFile, $cacheTTL, $contentType = 'application/json
             header('Content-Type: ' . $contentType);
             header('X-Cache: HIT');
             echo $data;
-            return true;
+            exit;
         }
     }
-    return false;
 }
 
 function proxyWriteCache($cacheFile, $data) {

--- a/client/public/api/config-loader.php
+++ b/client/public/api/config-loader.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Shared Configuration Loader
- * 
+ *
  * This file locates and loads the shared secrets.env.php file which lives
  * outside the public_html directory for security.
  */
@@ -9,26 +9,29 @@
 /**
  * Returns the centralized cache root directory path.
  */
-function get_proxy_cache_dir() {
-    return dirname(__DIR__, 3) . '/cache';
+const CONFIG_LOADER_RELATIVE_PATH = '/config/secrets.env.php';
+const CONFIG_LOADER_CACHE_DIR = '/cache';
+
+function getProxyCacheDir() {
+    return dirname(__DIR__, 3) . CONFIG_LOADER_CACHE_DIR;
 }
 
 /**
  * Returns the list of possible paths where the secrets.env.php configuration file might reside.
  */
-function get_proxy_config_paths() {
+function getProxyConfigPaths() {
     return [
         // From release dir: dirname(__DIR__, 3) / config
-        dirname(__DIR__, 3) . '/config/secrets.env.php',
+        dirname(__DIR__, 3) . CONFIG_LOADER_RELATIVE_PATH,
         // From symlinked dir (if current is at /home/user/current)
-        dirname($_SERVER['DOCUMENT_ROOT'] ?? '', 1) . '/config/secrets.env.php',
+        dirname($_SERVER['DOCUMENT_ROOT'] ?? '', 1) . CONFIG_LOADER_RELATIVE_PATH,
         // Absolute fallback for common cPanel structures if others fail
-        '/home/' . get_current_user() . '/config/secrets.env.php'
+        '/home/' . get_current_user() . CONFIG_LOADER_RELATIVE_PATH
     ];
 }
 
-function load_shared_config() {
-    $possiblePaths = get_proxy_config_paths();
+function loadSharedConfig() {
+    $possiblePaths = getProxyConfigPaths();
 
     foreach ($possiblePaths as $path) {
         if (file_exists($path)) {
@@ -43,7 +46,7 @@ function load_shared_config() {
 }
 
 // Execute immediately
-if (!load_shared_config()) {
+if (!loadSharedConfig()) {
     header('Content-Type: application/json');
     http_response_code(500);
     echo json_encode(['error' => 'Internal Server Error: Configuration missing']);

--- a/client/public/api/imagesCloudinary.php
+++ b/client/public/api/imagesCloudinary.php
@@ -23,8 +23,8 @@ $cursorHash = $nextCursor ? '_' . md5($nextCursor) : '_page1';
 $cacheFile = $ctx['cacheRootDir'] . '/api_responses/cld_' . $folder . $cursorHash . '.json';
 $cacheTTL = 300;
 
-if ($ctx['method'] === 'GET' && proxyServeCache($cacheFile, $cacheTTL)) {
-    exit;
+if ($ctx['method'] === 'GET') {
+    proxyServeCache($cacheFile, $cacheTTL);
 }
 
 $cloudName = defined('CLD_CLOUD_NAME') ? CLD_CLOUD_NAME : getenv('CLD_CLOUD_NAME');

--- a/client/public/api/imagesCloudinary.php
+++ b/client/public/api/imagesCloudinary.php
@@ -44,7 +44,7 @@ if (!in_array($method, $allowedMethods, true)) {
 }
 
 // 3. Rate Limiting
-$cacheRootDir = get_proxy_cache_dir();
+$cacheRootDir = getProxyCacheDir();
 if (!SecurityUtils::checkRateLimit($cacheRootDir . '/rate_limits', 30, 60)) {
     http_response_code(429);
     echo json_encode(['error' => 'Too Many Requests'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
@@ -69,7 +69,12 @@ if ($nextCursor && !preg_match('/^[a-zA-Z0-9_\-\/=+]+$/', $nextCursor)) {
 }
 
 // 5. Authentication
-$headers = function_exists('getallheaders') ? getallheaders() : (function_exists('apache_request_headers') ? apache_request_headers() : []);
+$headers = [];
+if (function_exists('getallheaders')) {
+    $headers = getallheaders();
+} elseif (function_exists('apache_request_headers')) {
+    $headers = apache_request_headers();
+}
 $headersLower = array_change_key_case($headers, CASE_LOWER);
 
 $authHeaderToken = $headersLower['x-proxy-token'] ?? '';
@@ -118,7 +123,9 @@ $queryParams = [
     'prefix'      => $folder . '/',
     'type'        => 'upload',
 ];
-if ($nextCursor) $queryParams['next_cursor'] = $nextCursor;
+if ($nextCursor) {
+    $queryParams['next_cursor'] = $nextCursor;
+}
 
 $apiUrl = "https://api.cloudinary.com/v1_1/{$cloudName}/resources/image?" . http_build_query($queryParams);
 
@@ -171,7 +178,9 @@ $shaped = [
 // 8. Cache result and output with safety flags
 $json = json_encode($shaped, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
 if ($method === 'GET') {
-    if (!is_dir(dirname($cacheFile))) mkdir(dirname($cacheFile), 0700, true);
+    if (!is_dir(dirname($cacheFile))) {
+        mkdir(dirname($cacheFile), 0700, true);
+    }
     file_put_contents($cacheFile . '.tmp', $json, LOCK_EX);
     rename($cacheFile . '.tmp', $cacheFile);
 }

--- a/client/public/api/imagesCloudinary.php
+++ b/client/public/api/imagesCloudinary.php
@@ -3,118 +3,36 @@
  * Cloudinary API Proxy (Hardened)
  */
 
-require_once __DIR__ . '/config-loader.php';
-require_once __DIR__ . '/security-utils.php';
+require_once __DIR__ . '/api-middleware.php';
 
-header('Content-Type: application/json');
-header('X-Content-Type-Options: nosniff');
+$ctx = proxyRunMiddleware(['GET', 'OPTIONS']);
 
-// 1. Strict Origin & Referer Validation
-$allowedOrigins = [
-    'https://nairobidevops.org',
-    'https://www.nairobidevops.org'
-];
-
-$validOrigin = SecurityUtils::validateOrigin($allowedOrigins);
-if (!empty($validOrigin)) {
-    header('Access-Control-Allow-Origin: ' . $validOrigin);
-    header('Vary: Origin');
-}
-
-// 2. Preflight Handling
-$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-$allowedMethods = ["GET", "POST", "OPTIONS"];
-
-if ($method === 'OPTIONS') {
-    if (!empty($validOrigin)) {
-        header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-        header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-Proxy-Token');
-        header('Access-Control-Max-Age: 86400');
-    }
-    http_response_code(204);
-    exit;
-}
-
-// 2.1 Hardened Method Allowlist
-if (!in_array($method, $allowedMethods, true)) {
-    http_response_code(405);
-    header('Allow: ' . implode(', ', $allowedMethods));
-    echo json_encode(['error' => 'Method Not Allowed'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
-}
-
-// 3. Rate Limiting
-$cacheRootDir = getProxyCacheDir();
-if (!SecurityUtils::checkRateLimit($cacheRootDir . '/rate_limits', 30, 60)) {
-    http_response_code(429);
-    echo json_encode(['error' => 'Too Many Requests'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
-}
-
-// 4. Input Validation
 $allowedFolders = ['ndcCampusTour', 'ndcPartners'];
 $folder = isset($_GET['folder']) ? trim($_GET['folder']) : '';
 $nextCursor = isset($_GET['next_cursor']) ? trim($_GET['next_cursor']) : '';
 
 if (!in_array($folder, $allowedFolders, true)) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Invalid folder'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
+    proxyJsonError('Invalid folder', 400);
 }
 
 if ($nextCursor && !preg_match('/^[a-zA-Z0-9_\-\/=+]+$/', $nextCursor)) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Invalid cursor'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
+    proxyJsonError('Invalid cursor', 400);
 }
 
-// 5. Authentication
-$headers = [];
-if (function_exists('getallheaders')) {
-    $headers = getallheaders();
-} elseif (function_exists('apache_request_headers')) {
-    $headers = apache_request_headers();
-}
-$headersLower = array_change_key_case($headers, CASE_LOWER);
-
-$authHeaderToken = $headersLower['x-proxy-token'] ?? '';
-if (preg_match('/Bearer\s+(.*)$/i', $authHeaderToken, $matches)) {
-    $authHeaderToken = trim($matches[1]);
-}
-
-$expectedToken = defined('PROXY_API_TOKEN') ? PROXY_API_TOKEN : getenv('PROXY_API_TOKEN');
-$isAjax = strtolower($headersLower['x-requested-with'] ?? '') === 'xmlhttprequest';
-$isAuthenticated = SecurityUtils::validateToken($authHeaderToken, $expectedToken);
-
-if (!$isAuthenticated && !( !empty($validOrigin) && $isAjax)) {
-    http_response_code(401);
-    echo json_encode(['error' => 'Unauthorized'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
-}
-
-// 6. Caching (GET requests only)
 $cursorHash = $nextCursor ? '_' . md5($nextCursor) : '_page1';
-$cacheFile = $cacheRootDir . '/api_responses/cld_' . $folder . $cursorHash . '.json';
+$cacheFile = $ctx['cacheRootDir'] . '/api_responses/cld_' . $folder . $cursorHash . '.json';
 $cacheTTL = 300;
 
-if ($method === 'GET' && file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTTL)) {
-    $cachedData = file_get_contents($cacheFile);
-    if ($cachedData) {
-        header('X-Cache: HIT');
-        echo $cachedData;
-        exit;
-    }
+if ($ctx['method'] === 'GET' && proxyServeCache($cacheFile, $cacheTTL)) {
+    exit;
 }
 
-// 7. Cloudinary Admin API Request
 $cloudName = defined('CLD_CLOUD_NAME') ? CLD_CLOUD_NAME : getenv('CLD_CLOUD_NAME');
 $apiKey    = defined('CLD_API_KEY') ? CLD_API_KEY : getenv('CLD_API_KEY');
 $apiSecret = defined('CLD_API_SECRET') ? CLD_API_SECRET : getenv('CLD_API_SECRET');
 
 if (!$cloudName || !$apiKey || !$apiSecret) {
-    http_response_code(500);
-    echo json_encode(['error' => 'Server configuration error'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
+    proxyJsonError('Server configuration error', 500);
 }
 
 $auth = base64_encode($apiKey . ':' . $apiSecret);
@@ -140,17 +58,12 @@ $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 curl_close($ch);
 
 if ($response === false || $http_code !== 200) {
-    http_response_code(502);
-    echo json_encode(['error' => 'Upstream error'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
+    proxyJsonError('Upstream error', 502);
 }
 
-// 8. Shape and Cache Response
 $data = json_decode($response, true);
 if (!$data || !isset($data['resources'])) {
-    http_response_code(502);
-    echo json_encode(['error' => 'Invalid upstream response'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
+    proxyJsonError('Invalid upstream response', 502);
 }
 
 $shapedResources = [];
@@ -172,18 +85,14 @@ $shaped = [
     'images'      => $shapedResources,
     'nextCursor'  => $data['next_cursor'] ?? null,
     'hasMore'     => !empty($data['next_cursor']),
-    'total'       => count($shapedResources), // Align with TS CloudinaryResponse type
+    'total'       => count($shapedResources),
 ];
 
-// 8. Cache result and output with safety flags
 $json = json_encode($shaped, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-if ($method === 'GET') {
-    if (!is_dir(dirname($cacheFile))) {
-        mkdir(dirname($cacheFile), 0700, true);
-    }
-    file_put_contents($cacheFile . '.tmp', $json, LOCK_EX);
-    rename($cacheFile . '.tmp', $cacheFile);
+if ($ctx['method'] === 'GET') {
+    proxyWriteCache($cacheFile, $json);
 }
 
+header('Content-Type: application/json; charset=utf-8');
 header('X-Cache: MISS');
 echo $json;

--- a/client/public/api/luma.php
+++ b/client/public/api/luma.php
@@ -1,13 +1,16 @@
 <?php
 /**
  * Luma Calendar API Proxy (Hardened)
- * 
- * Securely proxies requests to api.luma.com while enforcing 
+ *
+ * Securely proxies requests to api.luma.com while enforcing
  * authentication, origin validation, rate limiting, and caching.
  */
 
 require_once __DIR__ . '/config-loader.php';
 require_once __DIR__ . '/security-utils.php';
+
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+const CONTENT_TYPE_HEADER = 'Content-Type: ';
 
 header('X-Content-Type-Options: nosniff');
 
@@ -38,16 +41,21 @@ if ($method === 'OPTIONS') {
 }
 
 // 3. Rate Limiting (IP-based, outside public_html)
-$cacheRootDir = get_proxy_cache_dir(); // /home/user/cache
+$cacheRootDir = getProxyCacheDir(); // /home/user/cache
 if (!SecurityUtils::checkRateLimit($cacheRootDir . '/rate_limits', 30, 60)) {
     http_response_code(429);
-    header('Content-Type: application/json; charset=utf-8');
+    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
     echo json_encode(['error' => 'Too Many Requests'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
     exit;
 }
 
 // 4. Authentication (Supports Rotation)
-$headers = function_exists('getallheaders') ? getallheaders() : (function_exists('apache_request_headers') ? apache_request_headers() : []);
+$headers = [];
+if (function_exists('getallheaders')) {
+    $headers = getallheaders();
+} elseif (function_exists('apache_request_headers')) {
+    $headers = apache_request_headers();
+}
 $headersLower = array_change_key_case($headers, CASE_LOWER);
 
 $authHeaderToken = $headersLower['x-proxy-token'] ?? '';
@@ -62,7 +70,7 @@ $isAuthenticated = SecurityUtils::validateToken($authHeaderToken, $expectedToken
 // Fix the 401: If not authenticated by token, allow ONLY if Trusted Origin + AJAX
 if (!$isAuthenticated && !( !empty($validOrigin) && $isAjax)) {
     http_response_code(401);
-    header('Content-Type: application/json; charset=utf-8');
+    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
     echo json_encode(['error' => 'Unauthorized'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
     exit;
 }
@@ -71,7 +79,7 @@ if (!$isAuthenticated && !( !empty($validOrigin) && $isAjax)) {
 if (!in_array($method, $allowedMethods, true)) {
     http_response_code(405);
     header('Allow: ' . implode(', ', $allowedMethods));
-    header('Content-Type: application/json; charset=utf-8');
+    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
     echo json_encode(['error' => 'Method Not Allowed'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
     exit;
 }
@@ -84,7 +92,7 @@ $path = '/' . ltrim($path, '/');
 // Validate path
 if ($path === '/' || !preg_match('#^/[a-zA-Z0-9/_\.\-\?=&]*$#', $path) || strpos($path, '..') !== false) {
     http_response_code(400);
-    header('Content-Type: application/json; charset=utf-8');
+    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
     echo json_encode(['error' => 'Invalid path'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
     exit;
 }
@@ -107,10 +115,10 @@ $cacheTTL = 300; // 5 minutes
 if ($method === 'GET' && !$hasAuthorization && file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTTL)) {
     $cachedData = file_get_contents($cacheFile);
     $cacheMetaFile = $cacheFile . '.meta';
-    $cachedContentType = file_exists($cacheMetaFile) ? file_get_contents($cacheMetaFile) : 'application/json; charset=utf-8';
+    $cachedContentType = file_exists($cacheMetaFile) ? file_get_contents($cacheMetaFile) : JSON_CONTENT_TYPE;
     
     if ($cachedData) {
-        header('Content-Type: ' . $cachedContentType);
+        header(CONTENT_TYPE_HEADER . $cachedContentType);
         header('X-Cache: HIT');
         echo $cachedData;
         exit;
@@ -126,17 +134,25 @@ curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
 
-if ($method === 'HEAD') curl_setopt($ch, CURLOPT_NOBODY, true);
-if (in_array($method, ['POST', 'PUT', 'PATCH'])) {
-    curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
-}
+if ($method === 'HEAD') {
+        curl_setopt($ch, CURLOPT_NOBODY, true);
+    }
+    if (in_array($method, ['POST', 'PUT', 'PATCH'])) {
+        curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
+    }
 
-// Forward Authorization
-$forwardHeaders = [];
-$forwardAuthHeader = !empty($authContext) ? $authContext : null;
-if ($forwardAuthHeader) $forwardHeaders[] = 'Authorization: ' . preg_replace('/\v+/', '', $forwardAuthHeader);
-if (isset($_SERVER['CONTENT_TYPE'])) $forwardHeaders[] = 'Content-Type: ' . preg_replace('/\v+/', '', $_SERVER['CONTENT_TYPE']);
-if (!empty($forwardHeaders)) curl_setopt($ch, CURLOPT_HTTPHEADER, $forwardHeaders);
+    // Forward Authorization
+    $forwardHeaders = [];
+    $forwardAuthHeader = !empty($authContext) ? $authContext : null;
+    if ($forwardAuthHeader) {
+        $forwardHeaders[] = 'Authorization: ' . preg_replace('/\v+/', '', $forwardAuthHeader);
+    }
+    if (isset($_SERVER['CONTENT_TYPE'])) {
+        $forwardHeaders[] = CONTENT_TYPE_HEADER . preg_replace('/\v+/', '', $_SERVER['CONTENT_TYPE']);
+    }
+    if (!empty($forwardHeaders)) {
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $forwardHeaders);
+    }
 
 $response = curl_exec($ch);
 $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -145,7 +161,7 @@ $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
 if (curl_errno($ch)) {
     http_response_code(500);
     error_log('Luma Proxy Error: ' . curl_error($ch));
-    header('Content-Type: application/json; charset=utf-8');
+    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
     echo json_encode(['error' => 'Upstream failed'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
     curl_close($ch);
     exit;
@@ -154,11 +170,13 @@ curl_close($ch);
 
 // 8. Cache result and output
 http_response_code($http_code);
-header('Content-Type: ' . ($contentType ?: 'application/json; charset=utf-8'));
+header(CONTENT_TYPE_HEADER . ($contentType ?: JSON_CONTENT_TYPE));
 header('X-Cache: ' . ($hasAuthorization ? 'BYPASS' : 'MISS'));
 
 if ($method === 'GET' && !$hasAuthorization && $http_code === 200) {
-    if (!is_dir(dirname($cacheFile))) mkdir(dirname($cacheFile), 0700, true);
+    if (!is_dir(dirname($cacheFile))) {
+        mkdir(dirname($cacheFile), 0700, true);
+    }
     // Atomic write
     file_put_contents($cacheFile . '.tmp', $response, LOCK_EX);
     rename($cacheFile . '.tmp', $cacheFile);
@@ -169,4 +187,6 @@ if ($method === 'GET' && !$hasAuthorization && $http_code === 200) {
     }
 }
 
-if ($method !== 'HEAD') echo $response;
+if ($method !== 'HEAD') {
+    echo $response;
+}

--- a/client/public/api/luma.php
+++ b/client/public/api/luma.php
@@ -1,100 +1,21 @@
 <?php
 /**
  * Luma Calendar API Proxy (Hardened)
- *
- * Securely proxies requests to api.luma.com while enforcing
- * authentication, origin validation, rate limiting, and caching.
  */
 
-require_once __DIR__ . '/config-loader.php';
-require_once __DIR__ . '/security-utils.php';
+require_once __DIR__ . '/api-middleware.php';
 
 const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
 const CONTENT_TYPE_HEADER = 'Content-Type: ';
 
-header('X-Content-Type-Options: nosniff');
+$ctx = proxyRunMiddleware(['GET', 'POST', 'OPTIONS', 'HEAD']);
 
-// 1. Strict Origin & Referer Validation
-$allowedOrigins = [
-    'https://nairobidevops.org',
-    'https://www.nairobidevops.org'
-];
-
-$validOrigin = SecurityUtils::validateOrigin($allowedOrigins);
-if (!empty($validOrigin)) {
-    header("Access-Control-Allow-Origin: $validOrigin");
-    header("Vary: Origin");
-}
-
-// 2. Preflight Handling
-$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-$allowedMethods = ["GET", "POST", "OPTIONS", "HEAD"];
-
-if ($method === 'OPTIONS') {
-    if (!empty($validOrigin)) {
-        header("Access-Control-Allow-Methods: " . implode(", ", $allowedMethods));
-        header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-Proxy-Token");
-        header("Access-Control-Max-Age: 86400");
-    }
-    http_response_code(204);
-    exit;
-}
-
-// 3. Rate Limiting (IP-based, outside public_html)
-$cacheRootDir = getProxyCacheDir(); // /home/user/cache
-if (!SecurityUtils::checkRateLimit($cacheRootDir . '/rate_limits', 30, 60)) {
-    http_response_code(429);
-    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
-    echo json_encode(['error' => 'Too Many Requests'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
-}
-
-// 4. Authentication (Supports Rotation)
-$headers = [];
-if (function_exists('getallheaders')) {
-    $headers = getallheaders();
-} elseif (function_exists('apache_request_headers')) {
-    $headers = apache_request_headers();
-}
-$headersLower = array_change_key_case($headers, CASE_LOWER);
-
-$authHeaderToken = $headersLower['x-proxy-token'] ?? '';
-if (preg_match('/Bearer\s+(.*)$/i', $authHeaderToken, $matches)) {
-    $authHeaderToken = trim($matches[1]);
-}
-
-$expectedToken = defined('PROXY_API_TOKEN') ? PROXY_API_TOKEN : getenv('PROXY_API_TOKEN');
-$isAjax = strtolower($headersLower['x-requested-with'] ?? '') === 'xmlhttprequest';
-$isAuthenticated = SecurityUtils::validateToken($authHeaderToken, $expectedToken);
-
-// Fix the 401: If not authenticated by token, allow ONLY if Trusted Origin + AJAX
-if (!$isAuthenticated && !( !empty($validOrigin) && $isAjax)) {
-    http_response_code(401);
-    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
-    echo json_encode(['error' => 'Unauthorized'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
-}
-
-// 5. Hardened Method Allowlist
-if (!in_array($method, $allowedMethods, true)) {
-    http_response_code(405);
-    header('Allow: ' . implode(', ', $allowedMethods));
-    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
-    echo json_encode(['error' => 'Method Not Allowed'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
-}
-
-// 6. Build Target URL
 $base_url = 'https://api.luma.com';
 $path = isset($_GET['path']) ? (string)$_GET['path'] : '';
 $path = '/' . ltrim($path, '/');
 
-// Validate path
 if ($path === '/' || !preg_match('#^/[a-zA-Z0-9/_\.\-\?=&]*$#', $path) || strpos($path, '..') !== false) {
-    http_response_code(400);
-    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
-    echo json_encode(['error' => 'Invalid path'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-    exit;
+    proxyJsonError('Invalid path', 400);
 }
 
 $queryParams = $_GET;
@@ -105,88 +26,69 @@ if ($queryString !== '') {
     $target_url .= (strpos($path, '?') === false ? '?' : '&') . $queryString;
 }
 
-// 7. Caching (GET requests only)
-$authContext = $headersLower['authorization'] ?? $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+$authContext = $ctx['headersLower']['authorization'] ?? $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
 $hasAuthorization = trim($authContext) !== '';
 $cacheKey = md5($target_url . '|' . $authContext);
-$cacheFile = $cacheRootDir . '/api_responses/luma_' . $cacheKey . '.json';
-$cacheTTL = 300; // 5 minutes
+$cacheFile = $ctx['cacheRootDir'] . '/api_responses/luma_' . $cacheKey . '.json';
+$cacheTTL = 300;
 
-if ($method === 'GET' && !$hasAuthorization && file_exists($cacheFile) && (time() - filemtime($cacheFile) < $cacheTTL)) {
-    $cachedData = file_get_contents($cacheFile);
+if ($ctx['method'] === 'GET' && !$hasAuthorization) {
     $cacheMetaFile = $cacheFile . '.meta';
     $cachedContentType = file_exists($cacheMetaFile) ? file_get_contents($cacheMetaFile) : JSON_CONTENT_TYPE;
-    
-    if ($cachedData) {
-        header(CONTENT_TYPE_HEADER . $cachedContentType);
-        header('X-Cache: HIT');
-        echo $cachedData;
+    if (proxyServeCache($cacheFile, $cacheTTL, $cachedContentType)) {
         exit;
     }
 }
 
-// 7. Proxy the Request
 $ch = curl_init($target_url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 curl_setopt($ch, CURLOPT_TIMEOUT, 30);
-curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $ctx['method']);
 
-if ($method === 'HEAD') {
-        curl_setopt($ch, CURLOPT_NOBODY, true);
-    }
-    if (in_array($method, ['POST', 'PUT', 'PATCH'])) {
-        curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
-    }
+if ($ctx['method'] === 'HEAD') {
+    curl_setopt($ch, CURLOPT_NOBODY, true);
+}
+if (in_array($ctx['method'], ['POST', 'PUT', 'PATCH'])) {
+    curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
+}
 
-    // Forward Authorization
-    $forwardHeaders = [];
-    $forwardAuthHeader = !empty($authContext) ? $authContext : null;
-    if ($forwardAuthHeader) {
-        $forwardHeaders[] = 'Authorization: ' . preg_replace('/\v+/', '', $forwardAuthHeader);
-    }
-    if (isset($_SERVER['CONTENT_TYPE'])) {
-        $forwardHeaders[] = CONTENT_TYPE_HEADER . preg_replace('/\v+/', '', $_SERVER['CONTENT_TYPE']);
-    }
-    if (!empty($forwardHeaders)) {
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $forwardHeaders);
-    }
+$forwardHeaders = [];
+$forwardAuthHeader = !empty($authContext) ? $authContext : null;
+if ($forwardAuthHeader) {
+    $forwardHeaders[] = 'Authorization: ' . preg_replace('/\v+/', '', $forwardAuthHeader);
+}
+if (isset($_SERVER['CONTENT_TYPE'])) {
+    $forwardHeaders[] = CONTENT_TYPE_HEADER . preg_replace('/\v+/', '', $_SERVER['CONTENT_TYPE']);
+}
+if (!empty($forwardHeaders)) {
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $forwardHeaders);
+}
 
 $response = curl_exec($ch);
 $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
 
 if (curl_errno($ch)) {
-    http_response_code(500);
     error_log('Luma Proxy Error: ' . curl_error($ch));
-    header(CONTENT_TYPE_HEADER . JSON_CONTENT_TYPE);
-    echo json_encode(['error' => 'Upstream failed'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
     curl_close($ch);
-    exit;
+    proxyJsonError('Upstream failed', 500);
 }
 curl_close($ch);
 
-// 8. Cache result and output
 http_response_code($http_code);
 header(CONTENT_TYPE_HEADER . ($contentType ?: JSON_CONTENT_TYPE));
 header('X-Cache: ' . ($hasAuthorization ? 'BYPASS' : 'MISS'));
 
-if ($method === 'GET' && !$hasAuthorization && $http_code === 200) {
-    if (!is_dir(dirname($cacheFile))) {
-        mkdir(dirname($cacheFile), 0700, true);
-    }
-    // Atomic write
-    file_put_contents($cacheFile . '.tmp', $response, LOCK_EX);
-    rename($cacheFile . '.tmp', $cacheFile);
-    
-    // Cache Content-Type metadata
+if ($ctx['method'] === 'GET' && !$hasAuthorization && $http_code === 200) {
+    proxyWriteCache($cacheFile, $response);
     if ($contentType) {
         file_put_contents($cacheFile . '.meta', $contentType);
     }
 }
 
-if ($method !== 'HEAD') {
+if ($ctx['method'] !== 'HEAD') {
     echo $response;
 }

--- a/client/public/api/luma.php
+++ b/client/public/api/luma.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/api-middleware.php';
 const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
 const CONTENT_TYPE_HEADER = 'Content-Type: ';
 
-$ctx = proxyRunMiddleware(['GET', 'POST', 'OPTIONS', 'HEAD']);
+$ctx = proxyRunMiddleware(['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'HEAD']);
 
 $base_url = 'https://api.luma.com';
 $path = isset($_GET['path']) ? (string)$_GET['path'] : '';
@@ -35,9 +35,7 @@ $cacheTTL = 300;
 if ($ctx['method'] === 'GET' && !$hasAuthorization) {
     $cacheMetaFile = $cacheFile . '.meta';
     $cachedContentType = file_exists($cacheMetaFile) ? file_get_contents($cacheMetaFile) : JSON_CONTENT_TYPE;
-    if (proxyServeCache($cacheFile, $cacheTTL, $cachedContentType)) {
-        exit;
-    }
+    proxyServeCache($cacheFile, $cacheTTL, $cachedContentType);
 }
 
 $ch = curl_init($target_url);

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -21,11 +21,15 @@ export default function Navbar() {
   const [currentLocation, setCurrentLocation] = useState(location);
 
   useEffect(() => {
+    if (globalThis.window === undefined) {
+      return;
+    }
+
     // Sync active-route state on any wouter navigation.
     // Use browser URL (not wouter's hash-stripped location) to
     // preserve hash tracking for hash-aware link highlighting.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setCurrentLocation(window.location.pathname + window.location.hash);
+    setCurrentLocation(globalThis.window.location.pathname + globalThis.window.location.hash);
   }, [location]);
 
   const navLinks = [
@@ -37,13 +41,13 @@ export default function Navbar() {
   ];
 
   const handleNavClick = (href: string) => {
-    if (typeof window === "undefined" || typeof document === "undefined") return;
+    if (globalThis.window === undefined || globalThis.document === undefined) return;
 
     const openExternal = (raw: string) => {
       try {
         const u = new URL(raw);
         if (u.protocol !== "https:" && u.protocol !== "http:") return;
-        window.open(u.toString(), "_blank", "noopener,noreferrer");
+        globalThis.window?.open(u.toString(), "_blank", "noopener,noreferrer");
       } catch {
         return;
       }
@@ -60,14 +64,14 @@ export default function Navbar() {
       if (element) {
         element.scrollIntoView({ behavior: "smooth" });
 
-        if (window.location.hash !== href) {
-          window.history.replaceState(null, "", href);
+        if (globalThis.window?.location.hash !== href) {
+          globalThis.window?.history.replaceState(null, "", href);
         }
-        setCurrentLocation(window.location.pathname + href);
+        setCurrentLocation((globalThis.window?.location.pathname ?? "") + href);
       }
     } else if (/^(mailto|tel):/i.test(href)) {
       // handle mailto:, tel: specifically to avoid dangerous schemes like javascript:
-      window.location.assign(href);
+      globalThis.window?.location.assign(href);
     }
     // fallthrough handled by default browser behavior if needed,
     // but here we just no-op to prevent querySelector crashes.
@@ -77,12 +81,20 @@ export default function Navbar() {
 
   // update active link when navigation occurs (hash change / history)
   useEffect(() => {
-    const handleChange = () => setCurrentLocation(window.location.pathname + window.location.hash);
-    window.addEventListener("popstate", handleChange);
-    window.addEventListener("hashchange", handleChange);
+    if (globalThis.window === undefined) {
+      return undefined;
+    }
+
+    const handleChange = () => {
+      const location = globalThis.window.location;
+      setCurrentLocation(location.pathname + location.hash);
+    };
+
+    globalThis.window.addEventListener("popstate", handleChange);
+    globalThis.window.addEventListener("hashchange", handleChange);
     return () => {
-      window.removeEventListener("popstate", handleChange);
-      window.removeEventListener("hashchange", handleChange);
+      globalThis.window.removeEventListener("popstate", handleChange);
+      globalThis.window.removeEventListener("hashchange", handleChange);
     };
   }, []);
 

--- a/client/src/components/ui/StatisticCounter.tsx
+++ b/client/src/components/ui/StatisticCounter.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { default as CountUp } from "react-countup";
+import CountUp from "react-countup";
 import { useInView } from "react-intersection-observer";
 
 interface StatisticCounterProps {
@@ -10,7 +10,7 @@ interface StatisticCounterProps {
 
 const StatisticCounter = ({
   endValue,
-  duration = 2.0,
+  duration = 2,
   className = "text-2xl font-bold text-foreground",
 }: StatisticCounterProps) => {
   const { ref, inView } = useInView({
@@ -21,11 +21,12 @@ const StatisticCounter = ({
   const { numericValue, prefix, suffix } = useMemo(() => {
     const str = String(endValue);
     // find the first numeric substring (handles decimals and commas)
-    const match = str.match(/[-+]?\d[\d,]*\.?\d*/);
+    const regex = /[-+]?\d[\d,]*\.?\d*/;
+    const match = regex.exec(str);
     if (!match) {
-      return { numericValue: NaN, prefix: "", suffix: str };
+      return { numericValue: Number.NaN, prefix: "", suffix: str };
     }
-    const numStr = match[0].replace(/,/g, "");
+    const numStr = match[0].replaceAll(",", "");
     const prefix = str.slice(0, match.index ?? 0);
     const suffix = str.slice((match.index ?? 0) + match[0].length);
     return {
@@ -36,7 +37,7 @@ const StatisticCounter = ({
   }, [endValue]);
 
   // Fallback if the value cannot be parsed
-  if (isNaN(numericValue)) {
+  if (Number.isNaN(numericValue)) {
     return <span className={className}>{String(endValue)}</span>;
   }
 

--- a/client/src/hooks/use-mobile.tsx
+++ b/client/src/hooks/use-mobile.tsx
@@ -4,13 +4,17 @@ const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(
-    typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT
+    globalThis.window !== undefined && globalThis.window.innerWidth < MOBILE_BREAKPOINT
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    if (globalThis.window === undefined) {
+      return undefined;
+    }
+
+    const mql = globalThis.window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(globalThis.window.innerWidth < MOBILE_BREAKPOINT);
     };
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);

--- a/scripts/check-node-engine.js
+++ b/scripts/check-node-engine.js
@@ -88,23 +88,28 @@ function gatherDependencyList(packageJson) {
   return [...new Set([...dependencies, ...devDependencies])].sort((left, right) => left.localeCompare(right))
 }
 
-async function resolveDependencyVersion(name, packageJson, lockfile) {
-  // Handle npm v3+ lockfile format (uses packages object)
-  if (lockfile.packages) {
-    // Try root package first
-    const rootDep = lockfile.packages[`node_modules/${name}`]
-    if (rootDep?.version) return rootDep.version
-    // For scoped packages or other packages not matched directly,
-    // check entry keys, but ensure it's NOT a nested transitive dependency.
-    for (const [key, pkg] of Object.entries(lockfile.packages)) {
-      if (key.endsWith(`node_modules/${name}`) && pkg.version) {
-        const parts = key.split('node_modules')
-        if (parts.length <= 2) {
-          return pkg.version
-        }
-      }
+function findPackageVersion(packages, name) {
+  const rootDep = packages[`node_modules/${name}`]
+  if (rootDep?.version) return rootDep.version
+
+  for (const [key, pkg] of Object.entries(packages)) {
+    if (!key.endsWith(`node_modules/${name}`) || !pkg?.version) continue
+
+    const parts = key.split('node_modules')
+    if (parts.length <= 2) {
+      return pkg.version
     }
   }
+
+  return null
+}
+
+async function resolveDependencyVersion(name, packageJson, lockfile) {
+  if (lockfile.packages) {
+    const packageVersion = findPackageVersion(lockfile.packages, name)
+    if (packageVersion) return packageVersion
+  }
+
   // Fallback to v2 lockfile format (uses flat dependencies object)
   const locked = lockfile.dependencies?.[name]?.version
   if (locked) return locked


### PR DESCRIPTION
What does this PR do?
Fixes staging deploy workflow permission scoping and hardens the public API proxy layer. Also updates frontend runtime guards for SSR-safe navigation and mobile detection.

Linked issue
Closes #<!-- issue number -->

Type of change
 fix
What changed?
Updated [staging-deploy.yml](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to scope contents: read to the staging build job.
Refactored [config-loader.php](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with constants and cleaner helper names.
Hardened [imagesCloudinary.php](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [luma.php](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with safer header handling, JSON content-type constants, and atomic cache writes.
Added SSR-safe guards in [Navbar.tsx](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [use-mobile.tsx](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Cleaned up [StatisticCounter.tsx](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) numeric parsing logic.
Improved lockfile package resolution in [check-node-engine.js](vscode-file://vscode-app/c:/Users/jlc254/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Screenshots
N/A — no visual change

Breakpoints tested
 Mobile — 375px
 Tablet — 768px
 Desktop — 1280px
 Wide — 1536px+
How was this tested?
Reviewed diff changes across workflow, PHP, and frontend files.
Recommend running npm run build, npm run lint, and npm run typecheck before merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/325)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes staging deploy permissions and adds a shared PHP proxy middleware for `luma.php` and `imagesCloudinary.php` to unify CORS, token auth, rate limiting, method allowlists, and caching. Also adds SSR-safe guards in navigation/mobile code and improves npm lockfile version resolution.

- **Bug Fixes**
  - GitHub Actions: set minimal `contents: read` at the workflow and build job.
  - Proxies: adopt shared middleware; stricter origin/method/path checks, preflight + token auth, better GET cache hits with atomic writes; Luma preserves upstream content-type and supports HEAD/PUT/PATCH.
  - Runtime: SSR-safe `Navbar` and `useIsMobile` using `globalThis`.

- **Refactors**
  - Centralized proxy helpers in `api-middleware.php` (CORS/preflight, JSON/error helpers, rate limit, cache read/write); rename `config-loader.php` helpers to `getProxyCacheDir`, `getProxyConfigPaths`, `loadSharedConfig`.
  - `StatisticCounter`: use default import for `react-countup`, stronger numeric parsing, default duration 2.
  - `check-node-engine.js`: add `findPackageVersion` to improve nested `node_modules` version lookup.

<sup>Written for commit 822e1d78425b3d84d476ef68aa169e524b42f49d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

