### PR TITLE
fix: enhance SSH_PRIVATE_KEY validation in staging deploy workflow

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -126,8 +126,20 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
-          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          printf '%s' "$SSH_PRIVATE_KEY" | sed 's/\r$//' > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa ~/.ssh/known_hosts
+
+          if ! grep -qE '^-----BEGIN (OPENSSH|RSA) PRIVATE KEY-----$' ~/.ssh/id_rsa; then
+            echo "❌ SSH_PRIVATE_KEY is not a valid private key file."
+            echo "   Ensure the secret includes the full private key, including the BEGIN/END lines."
+            exit 1
+          fi
+
+          if ! ssh-keygen -y -f ~/.ssh/id_rsa >/dev/null 2>&1; then
+            echo "❌ SSH_PRIVATE_KEY could not be parsed by ssh-keygen."
+            echo "   Confirm the secret is the raw private key text, not a public key, passphrase-protected key, or malformed value."
+            exit 1
+          fi
 
       # 4. Create release directory on server
       - name: Create Release Directory


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/326)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves SSH private key handling in the staging deploy workflow to fail fast on bad keys and avoid CRLF issues. Adds clear validation and error messages to prevent flaky staging deploys.

- **Bug Fixes**
  - Write `SSH_PRIVATE_KEY` without a trailing newline and strip Windows CRs before saving to `~/.ssh/id_rsa`.
  - Validate key header (OPENSSH/RSA) and parseability with `ssh-keygen`; exit with clear, actionable errors if invalid.

<sup>Written for commit 2a0a209e62a607a142a9631f9b193513ca548f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

