### PR TITLE
fix(release): allow version bump commit to fail and propagate version…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,10 @@ jobs:
       - name: Bump frontend package.json & create tag
         id: update-version
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.tag_only != 'true'
+        # continue-on-error: the package.json commit push may be rejected by branch
+        # protection on main. The git tag and GitHub Release are the critical artifacts;
+        # the version bump commit will be applied via a follow-up PR if the push fails.
+        continue-on-error: true
         run: |
           V="${{ steps.semver.outputs.new_version }}"
           node -e "
@@ -238,17 +242,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add frontend/package.json
-          git commit -m "chore: release v${V}"
-          git push origin HEAD
+          git commit -m "chore: release v${V}" || true
+          git push origin HEAD || echo "::warning::Could not push version bump to protected branch — tag and release will still be created."
           git tag "v${V}"
           git push origin "v${V}"
           echo "new_version=${V}" >> "$GITHUB_OUTPUT"
 
-      # When recovering from a partial run (tag exists, release missing),
-      # propagate new_version so changelog + release steps can proceed.
-      - name: Propagate version (tag-only recovery)
+      # Propagate new_version when:
+      #   (a) recovering from a partial run where the tag exists but the release is missing, or
+      #   (b) the version-bump push was blocked by branch protection (continue-on-error)
+      #       so the output from update-version was never written.
+      - name: Propagate version (tag-only recovery or push-blocked)
         id: update-version-recovery
-        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.tag_only == 'true'
+        if: |
+          steps.guard.outputs.skip == 'false' &&
+          (steps.guard.outputs.tag_only == 'true' || steps.update-version.outcome == 'failure')
         run: |
           echo "new_version=${{ steps.semver.outputs.new_version }}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,12 +228,13 @@ jobs:
       - name: Bump frontend package.json & create tag
         id: update-version
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.tag_only != 'true'
-        # continue-on-error: the package.json commit push may be rejected by branch
-        # protection on main. The git tag and GitHub Release are the critical artifacts;
-        # the version bump commit will be applied via a follow-up PR if the push fails.
+        # continue-on-error: only git push failures are tolerated (via explicit exit 1
+        # below). Setup failures (node, git config) propagate normally and fail the step
+        # without triggering the push-blocked recovery path.
         continue-on-error: true
         run: |
           V="${{ steps.semver.outputs.new_version }}"
+
           node -e "
             const pkg = JSON.parse(require('fs').readFileSync('frontend/package.json','utf8'));
             pkg.version = '${V}';
@@ -242,10 +243,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add frontend/package.json
-          git commit -m "chore: release v${V}" || true
-          git push origin HEAD || echo "::warning::Could not push version bump to protected branch — tag and release will still be created."
+          # Only commit when there are actual staged changes; let real commit errors propagate.
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: release v${V}"
+          fi
+          # Let push failures propagate so continue-on-error and recovery logic work as intended.
+          if ! git push origin HEAD; then
+            echo "::warning::Could not push version bump to protected branch — tag and release will still be created."
+            exit 1
+          fi
           git tag "v${V}"
-          git push origin "v${V}"
+          if ! git push origin "v${V}"; then
+            echo "::warning::Could not push tag v${V} — GitHub Release will still be created."
+            exit 1
+          fi
           echo "new_version=${V}" >> "$GITHUB_OUTPUT"
 
       # Propagate new_version when:


### PR DESCRIPTION
## Summary by Sourcery

Allow the release workflow to tolerate failures when pushing the version bump commit while still creating tags and releases, and ensure the computed version is propagated in those scenarios.

CI:
- Relax the release job so the version bump commit push can fail without failing the workflow, while still tagging and releasing.
- Extend the version propagation step to handle both tag-only recovery and cases where the version-bump step failed due to a blocked push.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/340)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability and error handling to ensure consistent version propagation during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->