### PR TITLE
feat: add sync script for We Work Remotely jobs and implement useJobs…

### DIFF
--- a/backend/cron/works/migrate_clean_descriptions.php
+++ b/backend/cron/works/migrate_clean_descriptions.php
@@ -11,8 +11,8 @@
  *   php cron\works\migrate_clean_descriptions.php
  */
 
-require_once \dirname(__DIR__, 1) . '/db.php';
-require_once \dirname(__DIR__, 1) . '/helpers.php'; // provides cleanDescription()
+require_once \dirname(__DIR__) . '/db.php';
+require_once \dirname(__DIR__) . '/helpers.php'; // provides cleanDescription()
 
 $db = getDB();
 

--- a/backend/cron/works/migrate_clean_descriptions.php
+++ b/backend/cron/works/migrate_clean_descriptions.php
@@ -8,11 +8,11 @@
  * the same clean value, which is a no-op for the data).
  *
  * Run once from CLI:
- *   php cron\migrate_clean_descriptions.php
+ *   php cron\works\migrate_clean_descriptions.php
  */
 
-require_once \dirname(__DIR__) . '/db.php';
-require_once \dirname(__DIR__) . '/helpers.php'; // provides cleanDescription()
+require_once \dirname(__DIR__, 1) . '/db.php';
+require_once \dirname(__DIR__, 1) . '/helpers.php'; // provides cleanDescription()
 
 $db = getDB();
 

--- a/backend/cron/works/sync_remotive.php
+++ b/backend/cron/works/sync_remotive.php
@@ -699,103 +699,10 @@ function isRelevantForCategory(string $title, string $category): bool
 }
 
 // ── Salary helpers ────────────────────────────────────────────────────────────
-
-/**
- * Detect the currency symbol/code in a raw salary string.
- * Returns 'EUR', 'GBP', or 'USD' (default).
- */
-function detectCurrency(string $raw): string
-{
-    if (stripos($raw, 'EUR') !== false || strpos($raw, '€') !== false) {
-        return 'EUR';
-    }
-    if (stripos($raw, 'GBP') !== false || strpos($raw, '£') !== false) {
-        return 'GBP';
-    }
-    return 'USD';
-}
-
-/**
- * Detect the pay period in a raw salary string.
- * Returns 'annual' or 'monthly' (default).
- */
-function detectPeriod(string $raw): string
-{
-    $isAnnual = stripos($raw, 'year')   !== false
-             || stripos($raw, 'annual') !== false
-             || stripos($raw, 'yr')     !== false;
-
-    return $isAnnual ? 'annual' : 'monthly';
-}
-
-/**
- * Extract numeric salary figures from a raw string.
- * Handles formats like "$4,000", "70k", "90000".
- * Filters out spurious year values (< 500 or > 1,000,000).
- *
- * @return int[]
- */
-function extractNumbers(string $raw): array
-{
-    preg_match_all('/[\d,]+k?/i', $raw, $matches);
-    $numbers = [];
-
-    foreach ($matches[0] as $m) {
-        $m = str_replace(',', '', $m);
-        if (stripos($m, 'k') !== false) {
-            $m = (int) str_ireplace('k', '', $m) * 1000;
-        }
-        $numbers[] = (int) $m;
-    }
-
-    $numbers = array_filter($numbers, static fn (int $n): bool => $n >= 500 && $n <= 1_000_000);
-    return array_values($numbers);
-}
-
-/**
- * Parse a Remotive free-text salary string into structured min/max/currency/period.
- * Returns nulls for fields that cannot be parsed — callers must handle nulls.
- *
- * @return array{salary_min: int|null, salary_max: int|null, salary_currency: string, salary_period: string}
- */
-function parseSalary(string $raw): array
-{
-    $result = [
-        'salary_min'      => null,
-        'salary_max'      => null,
-        'salary_currency' => 'USD',
-        'salary_period'   => 'monthly',
-    ];
-
-    if (trim($raw) === '') {
-        return $result;
-    }
-
-    $result['salary_currency'] = detectCurrency($raw);
-    $result['salary_period']   = detectPeriod($raw);
-
-    $numbers = extractNumbers($raw);
-
-    if (\count($numbers) >= 2) {
-        $result['salary_min'] = min($numbers[0], $numbers[1]);
-        $result['salary_max'] = max($numbers[0], $numbers[1]);
-    } elseif (\count($numbers) === 1) {
-        $result['salary_min'] = $numbers[0];
-    }
-
-    // Normalise annual salaries to monthly for consistency across sources
-    if ($result['salary_period'] === 'annual') {
-        if ($result['salary_min'] !== null) {
-            $result['salary_min'] = (int) round($result['salary_min'] / 12);
-        }
-        if ($result['salary_max'] !== null) {
-            $result['salary_max'] = (int) round($result['salary_max'] / 12);
-        }
-        $result['salary_period'] = 'monthly';
-    }
-
-    return $result;
-}
+//
+// detectCurrency(), detectPeriod(), extractSalaryNumbers(), and parseSalary()
+// are defined in helpers.php and available via the require_once above.
+// They are shared with sync_wwremote.php.
 
 // ── Prepared INSERT statement (built once, reused for every new job) ──────────
 

--- a/backend/cron/works/sync_remotive.php
+++ b/backend/cron/works/sync_remotive.php
@@ -24,8 +24,9 @@ declare(strict_types=1);
 
 // ── Bootstrap ────────────────────────────────────────────────────────────────
 
-require_once \dirname(__DIR__) . '/db.php';
-require_once \dirname(__DIR__) . '/helpers.php';
+$basePath = __DIR__ . '/../../';
+require_once $basePath . 'db.php';
+require_once $basePath . 'helpers.php';
 
 $startTime = time();
 

--- a/backend/cron/works/sync_wwremote.php
+++ b/backend/cron/works/sync_wwremote.php
@@ -22,8 +22,9 @@ declare(strict_types=1);
 
 // ── Bootstrap ────────────────────────────────────────────────────────────────
 
-require_once \dirname(__DIR__) . '/db.php';
-require_once \dirname(__DIR__) . '/helpers.php';
+$basePath = \dirname(__FILE__) . '/../../';
+require_once $basePath . 'db.php';
+require_once $basePath . 'helpers.php';
 
 $startTime = time();
 

--- a/backend/cron/works/sync_wwremote.php
+++ b/backend/cron/works/sync_wwremote.php
@@ -505,6 +505,48 @@ function wwrIsRelevant(string $title): bool
     return false;
 }
 
+// ── Salary hint extractor ─────────────────────────────────────────────────────
+
+/**
+ * Scan a WWR job description CDATA block for salary patterns and return
+ * the first matching snippet for parseSalary() to process.
+ *
+ * WWR has no dedicated salary RSS field, so this is best-effort. It will
+ * match patterns like:
+ *   "$80,000 – $120,000/year"   →  "$80,000 – $120,000/year"
+ *   "Salary: $4,000/month"      →  "$4,000/month"
+ *   "€60k per year"             →  "€60k per year"
+ *
+ * Returns an empty string when no salary pattern is found, which causes
+ * parseSalary() to return all-null — that is the correct outcome for
+ * listings that don't publish compensation.
+ */
+function wwrExtractSalaryHint(string $descriptionCdata): string
+{
+    // Strip HTML so patterns aren't broken across tags (e.g. <strong>$80k</strong>)
+    $plain = strip_tags($descriptionCdata);
+
+    $patterns = [
+        // Range with currency: $80k – $120k, $80,000–$120,000
+        '/[\$€£][\d,]+k?\s*[-–—]\s*\$?[\d,]+k?(?:\s*\/\s*(?:year|yr|month|mo))?/i',
+        // "Salary: $X" or "Salary range: $X"
+        '/salary(?:\s+range)?[:\s]+[\$€£]?[\d,]+k?(?:\s*[-–]\s*[\$€£]?[\d,]+k?)?/i',
+        // "$X per year/month" or "$X/year"
+        '/[\$€£][\d,]+k?\s*(?:\/|\bper\b)\s*(?:year|yr|annual|month|mo)/i',
+        // "USD/EUR/GBP X" or "X USD"
+        '/(?:USD|EUR|GBP)\s+[\d,]+k?(?:\s*[-–]\s*[\d,]+k?)?/i',
+        '/[\d,]+k?\s*(?:USD|EUR|GBP)/i',
+    ];
+
+    foreach ($patterns as $pattern) {
+        if (preg_match($pattern, $plain, $match)) {
+            return $match[0];
+        }
+    }
+
+    return '';
+}
+
 // ── Deduplication ─────────────────────────────────────────────────────────────
 
 function wwrJobExists(PDO $db, string $sourceId): bool
@@ -519,17 +561,28 @@ function wwrJobExists(PDO $db, string $sourceId): bool
 // ── Refresh existing rows ─────────────────────────────────────────────────────
 
 /**
- * Keep already-stored WWR jobs clean across re-syncs.
- * Updates description when changed, backfills africa_friendly when now qualifying.
+ * Keep already-stored WWR jobs clean across re-syncs without re-inserting them.
+ *
+ * Required params:
+ *   $db, $sourceId, $cleanDesc, $locationDetail, $africaFriendly
+ *
+ * Optional enrichment via $extras array (all keys optional, safe to omit):
+ *   'logo'   string  — company_logo_url; backfilled when stored row is NULL
+ *   'tags'   string  — JSON-encoded tag array; backfilled when stored row is NULL
+ *   'salary' array   — parseSalary() result; backfilled when salary_min is NULL
  */
 function wwrRefreshJob(
     PDO    $db,
     string $sourceId,
     string $cleanDesc,
     string $locationDetail,
-    int    $africaFriendly
+    int    $africaFriendly,
+    array  $extras = []
 ): void {
-    // Refresh description when changed
+    $logoUrl = (string) ($extras['logo']   ?? '');
+    $tags    = (string) ($extras['tags']   ?? '[]');
+    $salary  = (array)  ($extras['salary'] ?? []);
+    // Refresh description when it has changed or was NULL
     $db->prepare(
         "UPDATE jobs
             SET description = :desc
@@ -559,6 +612,46 @@ function wwrRefreshJob(
                 AND africa_friendly = 0"
         )->execute([':sid' => $sourceId]);
     }
+
+    // Backfill company_logo_url when it was NULL and we now have a URL
+    if ($logoUrl !== '') {
+        $db->prepare(
+            "UPDATE jobs
+                SET company_logo_url = :logo
+              WHERE source = 'weworkremotely'
+                AND source_id = :sid
+                AND company_logo_url IS NULL"
+        )->execute([':logo' => $logoUrl, ':sid' => $sourceId]);
+    }
+
+    // Backfill tags when they were NULL
+    $db->prepare(
+        "UPDATE jobs
+            SET tags = :tags
+          WHERE source = 'weworkremotely'
+            AND source_id = :sid
+            AND tags IS NULL"
+    )->execute([':tags' => $tags, ':sid' => $sourceId]);
+
+    // Backfill salary fields when salary_min was NULL and we now have a value
+    if (!empty($salary['salary_min'])) {
+        $db->prepare(
+            "UPDATE jobs
+                SET salary_min      = :min,
+                    salary_max      = :max,
+                    salary_currency = :cur,
+                    salary_period   = :per
+              WHERE source = 'weworkremotely'
+                AND source_id = :sid
+                AND salary_min IS NULL"
+        )->execute([
+            ':min' => $salary['salary_min'],
+            ':max' => $salary['salary_max'],
+            ':cur' => $salary['salary_currency'],
+            ':per' => $salary['salary_period'],
+            ':sid' => $sourceId,
+        ]);
+    }
 }
 
 // ── Prepared INSERT ───────────────────────────────────────────────────────────
@@ -567,6 +660,7 @@ $insertStmt = $db->prepare("
     INSERT INTO jobs (
         title,
         company,
+        company_logo_url,
         description,
         apply_url,
         source,
@@ -575,6 +669,11 @@ $insertStmt = $db->prepare("
         location_type,
         location_detail,
         africa_friendly,
+        salary_min,
+        salary_max,
+        salary_currency,
+        salary_period,
+        tags,
         posted_at,
         is_active,
         is_approved,
@@ -582,6 +681,7 @@ $insertStmt = $db->prepare("
     ) VALUES (
         :title,
         :company,
+        :company_logo_url,
         :description,
         :apply_url,
         'weworkremotely',
@@ -590,6 +690,11 @@ $insertStmt = $db->prepare("
         'international_remote',
         :location_detail,
         :africa_friendly,
+        :salary_min,
+        :salary_max,
+        :salary_currency,
+        :salary_period,
+        :tags,
         :posted_at,
         1,
         1,
@@ -688,13 +793,71 @@ foreach ($feeds as $index => $feed) {
         // ── Description: strip HTML ───────────────────────────────────────────
         $description = cleanDescription($rawDescription);
 
+        // ── Company logo: prefer <enclosure url="...">, fall back to first <img> ──
+        // WWR RSS items include a company logo via an <enclosure> element.
+        // The URL lives in the 'url' XML attribute, not as element text, so
+        // SimpleXML accesses it via $item->enclosure['url'].
+        $logoUrl = '';
+        if (isset($item->enclosure) && !empty((string) $item->enclosure['url'])) {
+            $candidate = trim((string) $item->enclosure['url']);
+            if (filter_var($candidate, FILTER_VALIDATE_URL) !== false) {
+                $logoUrl = $candidate;
+            }
+        }
+        // Fallback: extract first <img src="..."> from description CDATA
+        if ($logoUrl === '' && preg_match('/<img[^>]+src=["\']([^"\']+)["\'][^>]*>/i', $rawDescription, $imgMatch)) {
+            $candidate = trim($imgMatch[1]);
+            if (filter_var($candidate, FILTER_VALIDATE_URL) !== false) {
+                $logoUrl = $candidate;
+            }
+        }
+
+        // ── Tags: collect RSS <category> elements + derive a slug from the feed URL ──
+        // WWR items may carry one or more <category> children.
+        // We also append the feed's category slug (e.g. "devops sysadmin")
+        // so every job has at least one searchable tag.
+        $rawTags = [];
+        foreach (($item->category ?? []) as $cat) {
+            $catStr = trim((string) $cat);
+            if ($catStr !== '') {
+                $rawTags[] = $catStr;
+            }
+        }
+        // Derive a human-readable tag from the feed URL slug
+        if (preg_match('/categories\/remote-(.+?)-jobs\.rss/', $feedUrl, $slugMatch)) {
+            $slugTag = str_replace('-', ' ', $slugMatch[1]);
+            if ($slugTag !== '' && !\in_array($slugTag, $rawTags, true)) {
+                $rawTags[] = $slugTag;
+            }
+        }
+        $tags = json_encode(
+            array_values(
+                array_filter(
+                    array_map('trim', $rawTags),
+                    static fn (string $t): bool => $t !== ''
+                )
+            ),
+            JSON_UNESCAPED_UNICODE
+        );
+
+        // ── Salary: attempt to parse from description CDATA ───────────────────
+        // WWR RSS has no dedicated salary field. We scan the plain-text version
+        // of the description for common salary patterns (e.g. "$80k–$120k/year",
+        // "USD 4,000/month"). This will be null for most listings — that is
+        // expected and acceptable; it matches what the source provides.
+        $salary = parseSalary(wwrExtractSalaryHint($rawDescription));
+
         // ── Posted at ─────────────────────────────────────────────────────────
         $parsedTime = strtotime($rawPubDate);
         $postedAt   = date('Y-m-d H:i:s', $parsedTime !== false ? $parsedTime : time());
 
         // ── Deduplication ─────────────────────────────────────────────────────
         if (wwrJobExists($db, $sourceId)) {
-            wwrRefreshJob($db, $sourceId, $description, $locationDetail, $africaFriendly);
+            wwrRefreshJob($db, $sourceId, $description, $locationDetail, $africaFriendly, [
+                'logo'   => $logoUrl,
+                'tags'   => $tags,
+                'salary' => $salary,
+            ]);
             $totalSkipped++;
             continue;
         }
@@ -708,15 +871,21 @@ foreach ($feeds as $index => $feed) {
         // ── Insert ────────────────────────────────────────────────────────────
         try {
             $insertStmt->execute([
-                ':title'          => $title,
-                ':company'        => $company,
-                ':description'    => $description,
-                ':apply_url'      => $applyUrl,
-                ':source_id'      => $sourceId,
-                ':role_type'      => $roleType,
+                ':title'           => $title,
+                ':company'         => $company,
+                ':company_logo_url' => $logoUrl !== '' ? $logoUrl : null,
+                ':description'     => $description,
+                ':apply_url'       => $applyUrl,
+                ':source_id'       => $sourceId,
+                ':role_type'       => $roleType,
                 ':location_detail' => $locationDetail !== '' ? $locationDetail : null,
                 ':africa_friendly' => $africaFriendly,
-                ':posted_at'      => $postedAt,
+                ':salary_min'      => $salary['salary_min'],
+                ':salary_max'      => $salary['salary_max'],
+                ':salary_currency' => $salary['salary_currency'],
+                ':salary_period'   => $salary['salary_period'],
+                ':tags'            => $tags,
+                ':posted_at'       => $postedAt,
             ]);
             $totalInserted++;
         } catch (PDOException $e) {

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -229,12 +229,13 @@ function detectPeriod(string $raw): string
 
     // No explicit period keyword — use magnitude heuristic.
     // Extract the largest numeric value in the string (honouring 'k' suffix).
-    preg_match_all('/[\d,]+k?/i', $raw, $matches);
+    // The pattern handles integers, comma-grouped numbers, and decimals (e.g. 25.5k).
+    preg_match_all('/[\d,]*\.?\d+k?/i', $raw, $matches);
     $max = 0;
     foreach ($matches[0] as $m) {
         $m = str_replace(',', '', $m);
         if (stripos($m, 'k') !== false) {
-            $val = (int) str_ireplace('k', '', $m) * 1000;
+            $val = (int) round((float) str_ireplace('k', '', $m) * 1000);
         } else {
             $val = (int) $m;
         }
@@ -256,13 +257,13 @@ function detectPeriod(string $raw): string
  */
 function extractSalaryNumbers(string $raw): array
 {
-    preg_match_all('/[\d,]+k?/i', $raw, $matches);
+    preg_match_all('/[\d,]*\.?\d+k?/i', $raw, $matches);
     $numbers = [];
 
     foreach ($matches[0] as $m) {
         $m = str_replace(',', '', $m);
         if (stripos($m, 'k') !== false) {
-            $m = (int) str_ireplace('k', '', $m) * 1000;
+            $m = (int) round((float) str_ireplace('k', '', $m) * 1000);
         }
         $numbers[] = (int) $m;
     }

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -176,6 +176,112 @@ function mapRoleType(string $title): string
     };
 }
 
+// ── Salary helpers ────────────────────────────────────────────────────────────
+//
+// These are shared by sync_remotive.php and sync_wwremote.php.
+// Remotive returns a dedicated salary string from its JSON API.
+// WWR has no salary field — the helpers are called on text extracted
+// from the job description CDATA when a salary pattern is found.
+
+/**
+ * Detect the currency symbol or code in a raw salary string.
+ * Returns 'EUR', 'GBP', or 'USD' (default).
+ */
+function detectCurrency(string $raw): string
+{
+    if (stripos($raw, 'EUR') !== false || str_contains($raw, '€')) {
+        return 'EUR';
+    }
+    if (stripos($raw, 'GBP') !== false || str_contains($raw, '£')) {
+        return 'GBP';
+    }
+    return 'USD';
+}
+
+/**
+ * Detect the pay period in a raw salary string.
+ * Returns 'annual' or 'monthly' (default).
+ */
+function detectPeriod(string $raw): string
+{
+    $isAnnual = stripos($raw, 'year')   !== false
+             || stripos($raw, 'annual') !== false
+             || stripos($raw, 'yr')     !== false;
+
+    return $isAnnual ? 'annual' : 'monthly';
+}
+
+/**
+ * Extract numeric salary figures from a raw string.
+ * Handles formats like "$4,000", "70k", "90000".
+ * Filters out spurious year values (< 500 or > 1,000,000).
+ *
+ * @return int[]
+ */
+function extractSalaryNumbers(string $raw): array
+{
+    preg_match_all('/[\d,]+k?/i', $raw, $matches);
+    $numbers = [];
+
+    foreach ($matches[0] as $m) {
+        $m = str_replace(',', '', $m);
+        if (stripos($m, 'k') !== false) {
+            $m = (int) str_ireplace('k', '', $m) * 1000;
+        }
+        $numbers[] = (int) $m;
+    }
+
+    $numbers = array_filter($numbers, static fn (int $n): bool => $n >= 500 && $n <= 1_000_000);
+    return array_values($numbers);
+}
+
+/**
+ * Parse a free-text salary string into structured min/max/currency/period.
+ *
+ * Returns nulls for fields that cannot be parsed — callers must handle nulls.
+ * Annual salaries are normalised to monthly for consistency across sources.
+ *
+ * @return array{salary_min: int|null, salary_max: int|null, salary_currency: string, salary_period: string}
+ */
+function parseSalary(string $raw): array
+{
+    $result = [
+        'salary_min'      => null,
+        'salary_max'      => null,
+        'salary_currency' => 'USD',
+        'salary_period'   => 'monthly',
+    ];
+
+    if (trim($raw) === '') {
+        return $result;
+    }
+
+    $result['salary_currency'] = detectCurrency($raw);
+    $result['salary_period']   = detectPeriod($raw);
+
+    $numbers = extractSalaryNumbers($raw);
+
+    if (\count($numbers) >= 2) {
+        $result['salary_min'] = min($numbers[0], $numbers[1]);
+        $result['salary_max'] = max($numbers[0], $numbers[1]);
+    } elseif (\count($numbers) === 1) {
+        $result['salary_min'] = $numbers[0];
+    }
+
+    // Normalise annual figures to monthly for consistency across sources
+    if ($result['salary_period'] === 'annual') {
+        if ($result['salary_min'] !== null) {
+            $result['salary_min'] = (int) round($result['salary_min'] / 12);
+        }
+        if ($result['salary_max'] !== null) {
+            $result['salary_max'] = (int) round($result['salary_max'] / 12);
+        }
+        $result['salary_period'] = 'monthly';
+    }
+
+    return $result;
+}
+
 /**
  * Build an affiliate URL if affiliate ID is defined.
  */

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -200,7 +200,14 @@ function detectCurrency(string $raw): string
 
 /**
  * Detect the pay period in a raw salary string.
- * Returns 'annual' or 'monthly' (default).
+ * Returns 'annual' or 'monthly'.
+ *
+ * Explicit keyword detection takes priority. When no keyword is present we
+ * fall back to a magnitude heuristic: if the largest numeric value found in
+ * the string is >= 20,000 we treat the figures as annual, since monthly
+ * salaries rarely reach that threshold. This prevents Remotive salaries that
+ * omit a period indicator (e.g. "$40,000–$60,000") from being misclassified
+ * as monthly and displayed without the ÷12 normalisation.
  */
 function detectPeriod(string $raw): string
 {
@@ -208,7 +215,36 @@ function detectPeriod(string $raw): string
              || stripos($raw, 'annual') !== false
              || stripos($raw, 'yr')     !== false;
 
-    return $isAnnual ? 'annual' : 'monthly';
+    if ($isAnnual) {
+        return 'annual';
+    }
+
+    $isMonthly = stripos($raw, 'month') !== false
+              || stripos($raw, '/mo')   !== false
+              || stripos($raw, 'mo.')   !== false;
+
+    if ($isMonthly) {
+        return 'monthly';
+    }
+
+    // No explicit period keyword — use magnitude heuristic.
+    // Extract the largest numeric value in the string (honouring 'k' suffix).
+    preg_match_all('/[\d,]+k?/i', $raw, $matches);
+    $max = 0;
+    foreach ($matches[0] as $m) {
+        $m = str_replace(',', '', $m);
+        if (stripos($m, 'k') !== false) {
+            $val = (int) str_ireplace('k', '', $m) * 1000;
+        } else {
+            $val = (int) $m;
+        }
+        if ($val > $max) {
+            $max = $val;
+        }
+    }
+
+    // Values >= 20,000 are almost certainly annual figures.
+    return $max >= 20_000 ? 'annual' : 'monthly';
 }
 
 /**

--- a/frontend/client/src/hooks/useJobs.ts
+++ b/frontend/client/src/hooks/useJobs.ts
@@ -1,0 +1,300 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type LocationType = "africa_remote" | "africa_onsite" | "international_remote";
+
+export type SortOption = "newest" | "closing_soon" | "salary_desc";
+
+export type JobSource = "remotive" | "weworkremotely";
+
+export type RoleType =
+  | "DevOps Engineer"
+  | "SRE"
+  | "Cloud Architect"
+  | "Platform Engineering"
+  | "Security"
+  | "Backend Engineer"
+  | "Frontend Engineer"
+  | "Sysadmin";
+
+export interface Job {
+  id: number;
+  title: string;
+  company: string;
+  company_logo_url: string | null;
+  role_type: RoleType | string;
+  location_type: LocationType;
+  location_detail: string | null;
+  africa_friendly: boolean;
+  salary_min: number | null;
+  salary_max: number | null;
+  salary_currency: string;
+  salary_period: "monthly" | "annual" | null;
+  experience_level: "junior" | "mid" | "senior" | "lead" | "any" | null;
+  tags: string[];
+  apply_url: string;
+  affiliate_apply_url: string | null;
+  source: JobSource;
+  posted_at: string;
+  closes_at: string | null;
+  days_remaining: number | null;
+  is_featured: boolean;
+  description: string;
+}
+
+export interface JobFilters {
+  /** Full-text search across title, company, and description */
+  q: string;
+  /** One or more role types e.g. ['DevOps Engineer', 'SRE'] */
+  role_type: RoleType[];
+  /** One or more location types */
+  location_type: LocationType[];
+  /** When true, only Africa-friendly roles are returned */
+  africa_friendly: boolean;
+  /** Sort order for results */
+  sort: SortOption;
+  /** Current page number (1-indexed) */
+  page: number;
+  /** Results per page (max 100) */
+  per_page: number;
+}
+
+interface JobsApiResponse {
+  total: number;
+  page: number;
+  per_page: number;
+  total_pages: number;
+  last_updated: string | null;
+  jobs: Job[];
+}
+
+interface UseJobsResult {
+  /** Job listings for the current page */
+  jobs: Job[];
+  /** Total number of matching jobs (across all pages) */
+  total: number;
+  /** Current page number */
+  page: number;
+  /** Total number of pages */
+  totalPages: number;
+  /** ISO timestamp of the last sync run */
+  lastUpdated: string | null;
+  /** Human-readable "X hours ago" / "Just now" string derived at fetch time */
+  lastSync: string;
+  /** True while a fetch is in flight */
+  isLoading: boolean;
+  /** True if the API returned an error or is unreachable */
+  isError: boolean;
+  /** Navigate to a specific page */
+  setPage: (page: number) => void;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Milliseconds to wait after the last keystroke before firing a search request */
+const SEARCH_DEBOUNCE_MS = 300;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build the query string from the active filters.
+ * Only appends params that have a non-empty value so the URL stays clean.
+ */
+function buildQueryString(filters: JobFilters): string {
+  const params = new URLSearchParams();
+
+  if (filters.q.trim()) {
+    params.set("q", filters.q.trim());
+  }
+
+  if (filters.role_type.length > 0) {
+    params.set("role_type", filters.role_type.join(","));
+  }
+
+  if (filters.location_type.length > 0) {
+    params.set("location_type", filters.location_type.join(","));
+  }
+
+  if (filters.africa_friendly) {
+    params.set("africa_friendly", "1");
+  }
+
+  if (filters.sort !== "newest") {
+    // 'newest' is the API default — no need to send it
+    params.set("sort", filters.sort);
+  }
+
+  params.set("page", String(filters.page));
+  params.set("per_page", String(filters.per_page));
+
+  return params.toString();
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches job listings from the PHP API with full filter, sort, and pagination support.
+ *
+ * Usage:
+ * ```tsx
+ * const { jobs, total, isLoading, isError, setPage } = useJobs(filters);
+ * ```
+ *
+ * Behaviour:
+ * - Search query (`q`) is debounced by 300 ms before fetching
+ * - Any filter change other than `page` resets pagination back to page 1
+ * - Stale responses are discarded — only the latest request updates state
+ * - Returns `isError: true` if the API is unreachable or returns a non-OK status
+ */
+export function useJobs(filters: JobFilters): UseJobsResult {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const [lastSync, setLastSync] = useState<string>("—");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  // Internal page state — owned by the hook so setPage can trigger a re-fetch
+  const [currentPage, setCurrentPage] = useState(filters.page);
+
+  // Debounced search term — updated after SEARCH_DEBOUNCE_MS of silence
+  const [debouncedQ, setDebouncedQ] = useState(filters.q);
+
+  // Track the previous filters (excluding q and page) to detect filter changes
+  const prevFiltersRef = useRef<Omit<JobFilters, "q" | "page"> | null>(null);
+
+  // ── Debounce the search query ───────────────────────────────────────────────
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQ(filters.q);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [filters.q]);
+
+  // ── Reset to page 1 when non-page filters change ────────────────────────────
+
+  useEffect(() => {
+    const nonPageFilters: Omit<JobFilters, "q" | "page"> = {
+      role_type: filters.role_type,
+      location_type: filters.location_type,
+      africa_friendly: filters.africa_friendly,
+      sort: filters.sort,
+      per_page: filters.per_page,
+    };
+
+    const prev = prevFiltersRef.current;
+
+    if (prev !== null && JSON.stringify(prev) !== JSON.stringify(nonPageFilters)) {
+      setCurrentPage(1);
+    }
+
+    prevFiltersRef.current = nonPageFilters;
+  }, [
+    filters.role_type,
+    filters.location_type,
+    filters.africa_friendly,
+    filters.sort,
+    filters.per_page,
+  ]);
+
+  // Reset to page 1 when the debounced search term changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [debouncedQ]);
+
+  // ── Fetch ───────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    // AbortController lets us cancel a stale in-flight request when a new
+    // one starts — prevents race conditions and out-of-order state updates
+    const controller = new AbortController();
+
+    const fetchJobs = async () => {
+      setIsLoading(true);
+      setIsError(false);
+
+      const activeFilters: JobFilters = {
+        ...filters,
+        q: debouncedQ,
+        page: currentPage,
+      };
+
+      const queryString = buildQueryString(activeFilters);
+      const apiBase = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+      const url = `${apiBase}/?action=jobs&${queryString}`;
+
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+
+        if (!response.ok) {
+          throw new Error(`API returned ${response.status}`);
+        }
+
+        const data: JobsApiResponse = await response.json();
+
+        setJobs(data.jobs);
+        setTotal(data.total);
+        setTotalPages(data.total_pages);
+        setLastUpdated(data.last_updated);
+
+        // Compute the human-readable age here (inside an effect) so that
+        // the component never needs to call Date.now() during render.
+        if (data.last_updated) {
+          const fetchedAt = Date.now();
+          const hours = Math.floor((fetchedAt - Date.parse(data.last_updated)) / (1000 * 60 * 60));
+          setLastSync(hours < 1 ? "Just now" : `${hours}h ago`);
+        } else {
+          setLastSync("—");
+        }
+      } catch (err) {
+        // Ignore AbortError — it's expected when a newer request cancels this one
+        if (err instanceof Error && err.name === "AbortError") return;
+
+        console.error("[useJobs] fetch failed:", err);
+        setIsError(true);
+        setJobs([]);
+        setTotal(0);
+        setTotalPages(0);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchJobs();
+
+    // Cancel the in-flight request when the effect re-runs or the component unmounts
+    return () => controller.abort();
+  }, [
+    debouncedQ,
+    filters.role_type,
+    filters.location_type,
+    filters.africa_friendly,
+    filters.sort,
+    filters.per_page,
+    currentPage,
+  ]);
+
+  // ── Public page setter ──────────────────────────────────────────────────────
+
+  const setPage = useCallback((page: number) => {
+    setCurrentPage(page);
+  }, []);
+
+  // ── Return ──────────────────────────────────────────────────────────────────
+
+  return {
+    jobs,
+    total,
+    page: currentPage,
+    totalPages,
+    lastUpdated,
+    lastSync,
+    isLoading,
+    isError,
+    setPage,
+  };
+}

--- a/frontend/client/src/hooks/useJobs.ts
+++ b/frontend/client/src/hooks/useJobs.ts
@@ -23,7 +23,7 @@ export interface Job {
   title: string;
   company: string;
   company_logo_url: string | null;
-  role_type: RoleType | string;
+  role_type: RoleType | (string & {});
   location_type: LocationType;
   location_detail: string | null;
   africa_friendly: boolean;
@@ -157,7 +157,17 @@ export function useJobs(filters: JobFilters): UseJobsResult {
   const [isError, setIsError] = useState(false);
 
   // Internal page state — owned by the hook so setPage can trigger a re-fetch
-  const [currentPage, setCurrentPage] = useState(filters.page);
+  const [currentPage, setCurrentPage] = useState<number>(filters.page);
+
+  // Sync internal page with external filters.page when they differ
+  useEffect(() => {
+    // Detect a change from external filters.page
+    const pageChanged = filters.page !== currentPage;
+    if (pageChanged) {
+      // Update currentPage to match filters.page, which will trigger a fetch
+      setCurrentPage(filters.page);
+    }
+  }, [filters.page, currentPage]);
 
   // Debounced search term — updated after SEARCH_DEBOUNCE_MS of silence
   const [debouncedQ, setDebouncedQ] = useState(filters.q);
@@ -250,6 +260,8 @@ export function useJobs(filters: JobFilters): UseJobsResult {
         } else {
           setLastSync("—");
         }
+
+        setIsLoading(false);
       } catch (err) {
         // Ignore AbortError — it's expected when a newer request cancels this one
         if (err instanceof Error && err.name === "AbortError") return;
@@ -259,7 +271,6 @@ export function useJobs(filters: JobFilters): UseJobsResult {
         setJobs([]);
         setTotal(0);
         setTotalPages(0);
-      } finally {
         setIsLoading(false);
       }
     };

--- a/frontend/client/src/pages/jobs.tsx
+++ b/frontend/client/src/pages/jobs.tsx
@@ -10,7 +10,7 @@ import {
   AlertCircle,
   RefreshCw,
 } from "lucide-react";
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
@@ -184,7 +184,8 @@ function UrgencyIndicator({ job }: { readonly job: Job }) {
         <span
           className="h-1.5 w-1.5 rounded-full bg-destructive animate-pulse"
           aria-hidden="true"
-        /> Closing today
+        />{" "}
+        Closing today
       </span>
     );
   }
@@ -224,7 +225,7 @@ function JobCard({ job }: { readonly job: Job }) {
   return (
     <article
       className={[
-        "flex flex-col md:flex-row gap-4 p-5 justify-between items-start md:items-center",
+        "relative flex flex-col md:flex-row gap-4 p-5 justify-between items-start md:items-center",
         "rounded-xl border transition-all duration-150",
         isFeatured
           ? "bg-[#141f16] border-primary/20 shadow-sm"
@@ -233,7 +234,7 @@ function JobCard({ job }: { readonly job: Job }) {
     >
       {/* Featured badge */}
       {isFeatured && (
-        <div className="absolute -mt-2 ml-4">
+        <div className="absolute -top-2 left-4">
           <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold bg-primary/20 text-primary border border-primary/30">
             ⭐ Featured
           </span>
@@ -287,8 +288,8 @@ function JobCard({ job }: { readonly job: Job }) {
                 {tag}
               </span>
             ))}
-            {job.tags.length > 4 && (
-              <span className="text-xs text-muted-foreground">+{job.tags.length - 4}</span>
+            {job.tags.length > 3 && (
+              <span className="text-xs text-muted-foreground">+{job.tags.length - 3}</span>
             )}
           </div>
 
@@ -392,7 +393,7 @@ function FilterPanel({
         {activeCount > 0 && (
           <button
             onClick={onClear}
-            className="text-xs font-semibold text-primary hover:underline focus:outline-none"
+            className="text-xs font-semibold text-primary hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Clear all
           </button>
@@ -575,7 +576,36 @@ export default function Jobs() {
   const totalMembers = statisticsData.find((s) => s.id === "community-members")?.number ?? "4,000+";
   const totalEvents = statisticsData.find((s) => s.id === "events")?.number ?? "70+";
 
-  const closingSoonCount = jobs.filter(
+  const [allJobsForCounting, setAllJobsForCounting] = useState<Job[]>([]);
+  const [allJobsFetched, setAllJobsFetched] = useState(false);
+
+  useEffect(() => {
+    if (allJobsFetched) return;
+
+    const controller = new AbortController();
+    const fetchAllJobs = async () => {
+      try {
+        const apiBase = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+        const url = `${apiBase}/?action=jobs&page=1&per_page=1000`;
+        const response = await fetch(url, { signal: controller.signal });
+        if (response.ok) {
+          const data = await response.json();
+          setAllJobsForCounting(data.jobs || []);
+        }
+      } catch (err) {
+        if (err instanceof Error && err.name !== "AbortError") {
+          console.error("Failed to fetch job count:", err);
+        }
+      } finally {
+        setAllJobsFetched(true);
+      }
+    };
+
+    fetchAllJobs();
+    return () => controller.abort();
+  }, [allJobsFetched]);
+
+  const closingSoonCount = allJobsForCounting.filter(
     (j) => j.days_remaining !== null && j.days_remaining <= 7
   ).length;
 
@@ -611,13 +641,13 @@ export default function Jobs() {
               {isLoading ? "—" : `${total} open roles`}
             </span>
             <span className="text-white/30 hidden md:inline">|</span>
-            <span className="text-white/70">
+            <span className="text-white/80">
               {closingSoonCount > 0
                 ? `${closingSoonCount} closing this week`
                 : "Updated " + lastSync}
             </span>
-            <span className="text-white/30 hidden md:inline">|</span>
-            <span className="text-white/50">Updated {lastSync}</span>
+            <span className="text-white/50 hidden md:inline">|</span>
+            <span className="text-white/70">Updated {lastSync}</span>
           </div>
 
           {/* Search bar */}
@@ -805,7 +835,11 @@ export default function Jobs() {
                 <Button
                   variant="outline"
                   className="mt-1 gap-2"
-                  onClick={() => patchFilters({ page: 1 })}
+                  onClick={() => {
+                    patchFilters({ page: 1 });
+                    // Force a fetch by updating filters without setting page
+                    setFilters((prev) => ({ ...prev, page: 1 }));
+                  }}
                 >
                   <RefreshCw className="h-4 w-4" />
                   Retry
@@ -857,7 +891,7 @@ export default function Jobs() {
       </main>
 
       {/* ── Employer CTA ─────────────────────────────────────────────────── */}
-      <section className="bg-ndc-darkblue text-white border-t border-white/10 py-16">
+      <section className="bg-ndc-darkblue text-[#F5F5F7] border-t border-white/10 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col lg:flex-row items-center justify-between gap-10">
             {/* Left: copy */}
@@ -871,12 +905,12 @@ export default function Jobs() {
                 Post a role and reach engineers actively building Africa&apos;s infrastructure.
               </p>
               <div className="flex flex-wrap gap-3 justify-center lg:justify-start pt-2">
-                <Button className="bg-primary text-white hover:bg-primary/90 font-semibold px-6">
+                <Button className="flex items-center text-lg px-8 py-4 hover:bg-white hover:text-primary transition-colors duration-200 overflow-hidden">
                   Post a Job →
                 </Button>
                 <Button
                   variant="outline"
-                  className="border-white/20 text-white hover:bg-white/10 font-medium px-6"
+                  className="flex items-center text-lg px-8 py-4 bg-white/10 border-white/20 text-white hover:bg-white hover:text-black overflow-hidden"
                 >
                   Learn about featuring
                 </Button>

--- a/frontend/client/src/pages/jobs.tsx
+++ b/frontend/client/src/pages/jobs.tsx
@@ -6,46 +6,11 @@ import {
   ChevronDown,
   SlidersHorizontal,
   Briefcase,
+  X,
+  AlertCircle,
+  RefreshCw,
 } from "lucide-react";
-import React, { useState, useMemo, useEffect } from "react";
-
-// Job shape — previously imported from src/data/jobsData.ts (now deleted).
-// Defined here so jobs.tsx is self-contained.
-interface Job {
-  id: string;
-  title: string;
-  company: string;
-  companyLogo?: string;
-  description: string;
-  location: string;
-  salaryMin: number;
-  salaryMax: number;
-  currency: string;
-  period: string;
-  tags: string[];
-  isAfricaFriendly: boolean;
-  isRemote: boolean;
-  postedAt: string;
-  closingIn?: string;
-  applyUrl?: string;
-  /** True when applyUrl is an absolute http(s) URL — validated at mapping time. */
-  isSafeUrl: boolean;
-  roleType:
-    | "Platform Engineering"
-    | "SRE"
-    | "Cloud Architect"
-    | "Security"
-    | "DevOps Engineer"
-    | "Sysadmin"
-    | "Frontend Engineer"
-    | "Backend Engineer";
-  locationTag:
-    | "Remote (Global)"
-    | "Remote (Africa Only)"
-    | "Nairobi, KE"
-    | "Lagos, NG"
-    | "Cape Town, ZA";
-}
+import React, { useState, useCallback } from "react";
 
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
@@ -62,234 +27,126 @@ import {
 } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { statisticsData } from "@/data/ndcData";
+import {
+  useJobs,
+  type Job,
+  type JobFilters,
+  type RoleType,
+  type LocationType,
+} from "@/hooks/useJobs";
 
-// NOTE: We fetch jobs from the backend endpoint and transform them into the
-// frontend Job shape defined in src/data/jobsData.ts. The transformer is
-// defensive and handles both the local demo shape and the backend (snake_case)
-// fields (e.g. salary_min, posted_at, tags as JSON/string).
+// ── Constants ─────────────────────────────────────────────────────────────────
 
-const matchesSearch = (job: Job, query: string): boolean => {
-  if (!query) return true;
+const ROLE_OPTIONS: RoleType[] = [
+  "DevOps Engineer",
+  "SRE",
+  "Platform Engineering",
+  "Cloud Architect",
+  "Backend Engineer",
+  "Frontend Engineer",
+  "Security",
+  "Sysadmin",
+];
+
+const LOCATION_OPTIONS: { label: string; value: LocationType }[] = [
+  { label: "Africa Remote", value: "africa_remote" },
+  { label: "Africa Onsite", value: "africa_onsite" },
+  { label: "International Remote", value: "international_remote" },
+];
+
+const SORT_OPTIONS = [
+  { label: "Newest first", value: "newest" },
+  { label: "Closing soon", value: "closing_soon" },
+  { label: "Salary: high–low", value: "salary_desc" },
+] as const;
+
+const DEFAULT_FILTERS: JobFilters = {
+  q: "",
+  role_type: [],
+  location_type: [],
+  africa_friendly: false,
+  sort: "newest",
+  page: 1,
+  per_page: 20,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the number of active filters (excluding page/per_page/sort/q).
+ * Used to show the active filter badge count on the mobile filter button.
+ */
+function countActiveFilters(filters: JobFilters): number {
   return (
-    job.title.toLowerCase().includes(query) ||
-    job.company.toLowerCase().includes(query) ||
-    job.description.toLowerCase().includes(query) ||
-    job.tags.some((tag) => tag.toLowerCase().includes(query))
+    filters.role_type.length + filters.location_type.length + (filters.africa_friendly ? 1 : 0)
   );
+}
+
+/** Map of common currency codes to their symbols. */
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  AUD: "A$",
+  CAD: "C$",
+  CHF: "CHF ",
+  INR: "₹",
+  NGN: "₦",
+  KES: "KSh ",
+  ZAR: "R ",
+  GHS: "GH₵ ",
 };
 
-const matchesQuickFilters = (job: Job, filters: string[]): boolean => {
-  if (filters.length === 0) return true;
-  return filters.every((filter) => {
-    if (filter === "Remote") return job.isRemote;
-    if (filter === "Kubernetes") return job.tags.includes("kubernetes");
-    if (filter === "Senior") return job.title.toLowerCase().includes("senior");
-    return true;
-  });
-};
+/** Resolve a currency code to a display symbol; falls back to the code itself. */
+function currencySymbol(code: string): string {
+  return CURRENCY_SYMBOLS[code] ?? `${code} `;
+}
 
-const normalizeTags = (tags: unknown[]): string[] =>
-  tags.map((tag) => String(tag).trim()).filter(Boolean);
+/**
+ * Format a salary range for display.
+ * Returns null when both min and max are null (not disclosed).
+ */
+function formatSalary(job: Job): string | null {
+  if (job.salary_min === null && job.salary_max === null) return null;
+  const currency = job.salary_currency ?? "USD";
+  const period = job.salary_period === "annual" ? "yr" : "mo";
+  const symbol = currencySymbol(currency);
 
-const parseJobTags = (tags: unknown): string[] => {
-  if (Array.isArray(tags)) {
-    return normalizeTags(tags);
+  if (job.salary_min !== null && job.salary_max !== null) {
+    return `${symbol}${job.salary_min.toLocaleString()} – ${symbol}${job.salary_max.toLocaleString()} / ${period}`;
   }
-
-  if (typeof tags === "string" && tags.length) {
-    try {
-      const parsed = JSON.parse(tags);
-      if (Array.isArray(parsed)) {
-        return normalizeTags(parsed);
-      }
-      return [];
-    } catch {
-      return normalizeTags(tags.split(","));
-    }
+  if (job.salary_min !== null) {
+    return `From ${symbol}${job.salary_min.toLocaleString()} / ${period}`;
   }
+  return `Up to ${symbol}${job.salary_max!.toLocaleString()} / ${period}`;
+}
 
-  return [];
-};
+/**
+ * Derive a human-readable posted-at label from an ISO datetime string.
+ */
+function formatPostedAt(postedAt: string): string {
+  const then = Date.parse(postedAt);
+  if (Number.isNaN(then)) return postedAt;
+  const hours = Math.floor((Date.now() - then) / (1000 * 60 * 60));
+  if (hours < 1) return "Just now";
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks === 1) return "1 week ago";
+  return `${weeks} weeks ago`;
+}
 
-// Safely convert unknown values to string without accidentally producing
-// "[object Object]". Prefer primitives; fall back to JSON.stringify for
-// objects when reasonable.
-const safeString = (v: unknown): string => {
-  if (v === null || v === undefined) return "";
-  if (typeof v === "string") return v;
-  if (typeof v === "number" || typeof v === "boolean") return String(v);
-  // For objects/arrays, JSON.stringify is more explicit than String(obj),
-  // and avoids the default "[object Object]" representation.
-  try {
-    const j = JSON.stringify(v);
-    // Avoid returning empty objects as strings in cases where that isn't helpful
-    return j === undefined || j === "{}" ? "" : j;
-  } catch {
-    return "";
-  }
-};
+// ── Sub-components ────────────────────────────────────────────────────────────
 
-const str = (v: unknown): string => safeString(v);
-const strOr = (...vals: unknown[]): string => {
-  for (const v of vals) {
-    const s = safeString(v);
-    if (s !== "") return s;
-  }
-  return "";
-};
-const numOr = (...vals: unknown[]): number => {
-  for (const v of vals) {
-    const n = Number(v);
-    if (v !== null && v !== undefined && !Number.isNaN(n)) return n;
-  }
-  return 0;
-};
-
-// parsePostedAt is defined at module level (not inside the component) so it is
-// a stable reference and does not need to appear in useMemo dependency arrays.
-const parsePostedAt = (posted: string, nowMs: number): number => {
-  const num = Number.parseInt(posted, 10);
-  if (Number.isNaN(num)) return 999;
-  if (posted.includes("h ago")) return num;
-  if (posted.includes("d ago")) return num * 24;
-  // handle ISO datetimes by returning hours since posted (smaller = newer)
-  if (/\d{4}-\d{2}-\d{2}T?/.test(posted)) {
-    const then = Date.parse(posted);
-    if (!Number.isNaN(then)) {
-      return Math.floor((nowMs - then) / (1000 * 60 * 60));
-    }
-  }
-  return num;
-};
-
-// Extract closing window from days_remaining or closingIn field.
-const extractDaysRemaining = (jobObj: Record<string, unknown>): number | undefined => {
-  const raw = jobObj.days_remaining ?? jobObj.daysRemaining;
-  if (raw === undefined || raw === null) return undefined;
-  const num = Number(raw);
-  return Number.isNaN(num) ? undefined : num;
-};
-
-// Extract closing window text from closingIn field.
-const extractClosingInText = (jobObj: Record<string, unknown>): string | undefined => {
-  const raw = jobObj.closingIn ?? jobObj.closing_in;
-  if (raw === undefined || raw === null) return undefined;
-  if (typeof raw === "string") return raw;
-  if (typeof raw === "number" && !Number.isNaN(raw)) return String(raw);
-  const s = safeString(raw);
-  return s === "" ? undefined : s;
-};
-
-const determineClosingIn = (jobObj: Record<string, unknown>): string | undefined => {
-  const hasClosingDate = jobObj.closes_at ?? jobObj.closesAt;
-  if (!hasClosingDate) return extractClosingInText(jobObj);
-
-  const days = extractDaysRemaining(jobObj);
-  if (days === undefined) return extractClosingInText(jobObj);
-  if (days === 0) return "today";
-  if (days > 0) return `${days}d`;
-  return extractClosingInText(jobObj);
-};
-
-const determineRoleType = (raw: string, validRoles: string[]) =>
-  validRoles.includes(raw) ? raw : "DevOps Engineer";
-
-// Extract city from location detail string.
-const extractCityFromDetail = (
-  locDetail: string
-): "Nairobi, KE" | "Lagos, NG" | "Cape Town, ZA" | null => {
-  const lower = locDetail.toLowerCase();
-  if (lower.includes("nairobi")) return "Nairobi, KE";
-  if (lower.includes("lagos")) return "Lagos, NG";
-  if (lower.includes("cape town") || lower.includes("cape-town")) return "Cape Town, ZA";
-  return null;
-};
-
-const determineLocationTag = (
-  locType: string,
-  locDetail: string
-): "Remote (Global)" | "Remote (Africa Only)" | "Nairobi, KE" | "Lagos, NG" | "Cape Town, ZA" => {
-  if (locType === "africa_remote") return "Remote (Africa Only)";
-  const city = extractCityFromDetail(locDetail);
-  if (locType === "africa_onsite") return city ?? "Remote (Africa Only)";
-  return city ?? "Remote (Global)";
-};
-
-// Defensively extract company logo URL from various backend shapes.
-// Avoids String(object) => "[object Object]" bug.
-const extractCompanyLogoUrl = (raw: unknown): string | undefined => {
-  if (typeof raw === "string" && raw.trim() !== "") return raw;
-  if (raw && typeof raw === "object") {
-    // common shapes: { url: string } or { src: string }
-    const asRec = raw as Record<string, unknown>;
-    const maybe = asRec.url ?? asRec.src ?? asRec.path ?? asRec.logo;
-    if (typeof maybe === "string" && maybe.trim() !== "") return maybe;
-  }
-  return undefined;
-};
-
-const mapBackendJobToFrontendJob = (j: Record<string, unknown>): Job => {
-  // backend uses snake_case; transform defensively
-  const tags = parseJobTags(j.tags);
-  const salaryMin = numOr(j.salary_min, j.salaryMin);
-  const salaryMax = numOr(j.salary_max, j.salaryMax);
-  const currency = strOr(j.currency, "$");
-  const period = strOr(j.period, "mo");
-  const isAfricaFriendly = Boolean(j.is_africa_friendly ?? j.isAfricaFriendly ?? false);
-  const isRemote = Boolean(j.is_remote ?? j.isRemote ?? false);
-  const postedAt = strOr(j.posted_at, j.postedAt, j.postedAtAgo);
-  const closingIn = determineClosingIn(j);
-  const rawRoleType = strOr(j.role_type, j.roleType, j.role, "DevOps Engineer");
-  const validRoles = [
-    "Platform Engineering",
-    "SRE",
-    "Cloud Architect",
-    "Security",
-    "DevOps Engineer",
-    "Sysadmin",
-    "Frontend Engineer",
-    "Backend Engineer",
-  ] as const;
-  type RoleType = (typeof validRoles)[number];
-  const roleType = determineRoleType(rawRoleType, validRoles as unknown as string[]) as RoleType;
-  const applyUrl = strOr(j.affiliate_apply_url, j.apply_url, j.applyUrl) || undefined;
-  const isSafeUrl = typeof applyUrl === "string" && /^https?:\/\//.test(applyUrl);
-  const rawLocType = strOr(j.location_type, j.locationType);
-  const rawLocDetail = strOr(j.location_detail, j.location, j.location_label);
-  const locationTag = determineLocationTag(rawLocType, rawLocDetail);
-  const companyLogoRaw = j.company_logo_url ?? j.company_logo ?? j.companyLogo;
-  const companyLogo = extractCompanyLogoUrl(companyLogoRaw);
-
-  return {
-    id: strOr(j.id, j.job_id),
-    title: str(j.title),
-    company: strOr(j.company, j.company_name),
-    companyLogo,
-    description: str(j.description),
-    location: rawLocDetail,
-    salaryMin,
-    salaryMax,
-    currency,
-    period,
-    tags: tags.map((t: unknown) => String(t).toLowerCase()),
-    isAfricaFriendly,
-    isRemote,
-    postedAt,
-    closingIn,
-    isSafeUrl,
-    applyUrl,
-    roleType,
-    locationTag,
-  };
-};
-
-// CompanyLogo uses `key={logoUrl}` at the call-site to remount when the URL
-// changes, which resets hasError to false without needing a setState-in-effect.
+/** Company logo with graceful fallback to a briefcase icon. */
 function CompanyLogo({
   logoUrl,
   companyName,
 }: {
-  readonly logoUrl?: string;
+  readonly logoUrl: string | null;
   readonly companyName: string;
 }) {
   const [hasError, setHasError] = useState(false);
@@ -299,7 +156,7 @@ function CompanyLogo({
       <img
         src={logoUrl}
         alt={`${companyName} logo`}
-        className="w-full h-full object-cover rounded-lg"
+        className="w-full h-full object-contain rounded-lg"
         onError={() => setHasError(true)}
       />
     );
@@ -308,239 +165,169 @@ function CompanyLogo({
   return <Briefcase className="h-5 w-5 text-muted-foreground" />;
 }
 
-// Sidebar content extracted to a module-level component to reduce Jobs
-// component complexity and avoid deep nesting.
-function FilterSidebar({
-  selectedRoles,
-  selectedLocations,
-  africaFriendly,
-  roleOptions,
-  locationOptions,
-  onRoleToggle,
-  onLocationToggle,
-  onAfricaToggle,
-  onClear,
-}: Readonly<{
-  selectedRoles: string[];
-  selectedLocations: string[];
-  africaFriendly: boolean;
-  roleOptions: string[];
-  locationOptions: string[];
-  onRoleToggle: (r: string) => void;
-  onLocationToggle: (l: string) => void;
-  onAfricaToggle: (v: boolean) => void;
-  onClear: () => void;
-}>) {
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between border-b border-border pb-4">
-        <div>
-          <h2 className="text-lg font-bold text-foreground">Filters</h2>
-          <p className="text-xs text-muted-foreground">Browse by Category</p>
-        </div>
-        <button
-          onClick={onClear}
-          className="text-xs font-semibold text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm"
-        >
-          Clear
-        </button>
-      </div>
-
-      <div className="space-y-3">
-        <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-          ROLE TYPE
-        </span>
-        <div className="space-y-2">
-          {roleOptions.map((role) => {
-            const id = `role-${role.replace(/\s+/g, "-").toLowerCase()}`;
-            return (
-              <div key={role} className="flex items-center space-x-2.5">
-                <label
-                  htmlFor={id}
-                  className="flex items-center space-x-2.5 text-sm text-foreground font-medium cursor-pointer"
-                >
-                  <Checkbox
-                    id={id}
-                    checked={selectedRoles.includes(role)}
-                    onCheckedChange={() => onRoleToggle(role)}
-                    className="border-border data-[state=checked]:bg-primary data-[state=checked]:border-primary"
-                  />
-                  <span>{role}</span>
-                </label>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="space-y-3 pt-4 border-t border-border">
-        <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-          LOCATION
-        </span>
-        <div className="space-y-2">
-          {locationOptions.map((loc) => {
-            const id = `location-${loc.replace(/\s+/g, "-").toLowerCase()}`;
-            return (
-              <div key={loc} className="flex items-center space-x-2.5">
-                <label
-                  htmlFor={id}
-                  className="flex items-center space-x-2.5 text-sm text-foreground font-medium cursor-pointer"
-                >
-                  <Checkbox
-                    id={id}
-                    checked={selectedLocations.includes(loc)}
-                    onCheckedChange={() => onLocationToggle(loc)}
-                    className="border-border data-[state=checked]:bg-primary data-[state=checked]:border-primary"
-                  />
-                  <span>{loc}</span>
-                </label>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="pt-4 border-t border-border flex items-center justify-between">
-        <div>
-          <span className="text-xs font-bold uppercase tracking-wider text-primary block">
-            AFRICA-FRIENDLY
-          </span>
-          <span className="text-xs text-muted-foreground">Visas/Timezones</span>
-        </div>
-        <Switch
-          checked={africaFriendly}
-          onCheckedChange={onAfricaToggle}
-          role="switch"
-          aria-checked={africaFriendly}
-          aria-label="Toggle Africa-Friendly jobs filter"
-          className="data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted"
-        />
-      </div>
-    </div>
-  );
-}
-
-// Simple string hash for deterministic tag rotation
-const simpleHash = (s: string): number => {
-  let hash = 0;
-  for (let i = 0; i < s.length; i++) {
-    hash = Math.trunc(hash * 31 + (s.codePointAt(i) ?? 0));
+/** Expiry urgency indicator shown on each job card. */
+function UrgencyIndicator({ job }: { readonly job: Job }) {
+  if (job.closes_at === null) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
+        {formatPostedAt(job.posted_at)}
+      </span>
+    );
   }
-  return Math.abs(hash);
-};
 
-// Render tags for a job (extracted to reduce cognitive complexity / nesting)
-function JobTags({ job }: Readonly<{ job: Job }>) {
-  const MAX_TAGS = 3;
-  const allTags = job.tags;
-  let displayed = allTags;
-  if (allTags.length > MAX_TAGS) {
-    const offset = simpleHash(job.id) % allTags.length;
-    const rotated = [...allTags.slice(offset), ...allTags.slice(0, offset)];
-    displayed = rotated.slice(0, MAX_TAGS);
-  }
-  const remaining = Math.max(0, allTags.length - displayed.length);
-  return (
-    <>
-      {displayed.map((tag) => (
+  const days = job.days_remaining ?? 0;
+
+  if (days === 0) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs font-semibold text-destructive">
         <span
-          key={tag}
-          className="inline-flex items-center px-2.5 py-1 rounded-full text-xs bg-muted text-muted-foreground font-medium"
-        >
-          {tag}
-        </span>
-      ))}
-      {remaining > 0 && (
-        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs bg-accent border border-border text-muted-foreground font-semibold">
-          +{remaining} more
-        </span>
-      )}
-    </>
+          className="h-1.5 w-1.5 rounded-full bg-destructive animate-pulse"
+          aria-hidden="true"
+        /> Closing today
+      </span>
+    );
+  }
+
+  if (days <= 7) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs font-semibold text-amber-500">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+        🔴 Closes in {days}d — act fast
+      </span>
+    );
+  }
+
+  if (days <= 14) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-amber-500">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />⚠ Closes in {days}d
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
+      Closes in {days}d
+    </span>
   );
 }
 
-function JobCard({
-  job,
-  renderUrgencyIndicator,
-}: Readonly<{
-  job: Job;
-  renderUrgencyIndicator: (job: Job) => React.ReactNode;
-}>) {
+/** A single job listing card. */
+function JobCard({ job }: { readonly job: Job }) {
+  const salary = formatSalary(job);
+  const applyUrl = job.affiliate_apply_url ?? job.apply_url;
+  const isSafeUrl = /^https?:\/\//.test(applyUrl);
+  const isFeatured = job.is_featured;
+
   return (
     <article
-      key={job.id}
-      className="flex flex-col md:flex-row gap-4 p-5 justify-between items-start md:items-center bg-card border border-border rounded-xl transition-all duration-300 hover:shadow-md hover:border-primary/20"
+      className={[
+        "flex flex-col md:flex-row gap-4 p-5 justify-between items-start md:items-center",
+        "rounded-xl border transition-all duration-150",
+        isFeatured
+          ? "bg-[#141f16] border-primary/20 shadow-sm"
+          : "bg-card border-border hover:bg-accent/30 hover:border-primary/20",
+      ].join(" ")}
     >
+      {/* Featured badge */}
+      {isFeatured && (
+        <div className="absolute -mt-2 ml-4">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold bg-primary/20 text-primary border border-primary/30">
+            ⭐ Featured
+          </span>
+        </div>
+      )}
+
+      {/* Left: logo + details */}
       <div className="flex gap-4 items-start flex-1 w-full">
-        <div className="w-12 h-12 rounded-lg bg-accent/30 border border-border flex items-center justify-center shrink-0 text-foreground font-bold text-lg">
+        <div className="w-12 h-12 rounded-lg bg-accent/30 border border-border flex items-center justify-center shrink-0">
           <CompanyLogo
-            key={job.companyLogo ?? job.id}
-            logoUrl={job.companyLogo}
+            key={job.company_logo_url ?? job.id}
+            logoUrl={job.company_logo_url}
             companyName={job.company}
           />
         </div>
 
         <div className="space-y-1.5 flex-1 min-w-0">
+          {/* Title + company */}
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-            <h3 className="text-lg font-bold text-foreground tracking-tight hover:text-primary transition-colors cursor-pointer">
-              {job.title}
-            </h3>
-            <span className="text-sm text-muted-foreground font-medium">{job.company}</span>
+            <h3 className="text-base font-semibold text-foreground leading-snug">{job.title}</h3>
+            <span className="text-sm text-muted-foreground">{job.company}</span>
           </div>
 
-          <p className="text-sm text-muted-foreground line-clamp-2 leading-relaxed">
-            {job.description}
-          </p>
-
-          <div className="flex flex-wrap items-center gap-2 pt-2.5">
-            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-accent border border-border text-foreground font-medium">
-              <MapPin className="h-3 w-3 text-muted-foreground" />
-              {job.location}
+          {/* Badges row */}
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            {/* Location type */}
+            <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs bg-blue-500/10 border border-blue-500/20 text-blue-500 font-medium">
+              <MapPin className="h-3 w-3" />
+              {job.location_detail ?? job.location_type.replaceAll("_", " ")}
             </span>
 
-            {job.salaryMin === 0 && job.salaryMax === 0 ? (
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-primary/10 border border-primary/20 text-primary font-bold">
-                Not Disclosed
+            {/* Africa-friendly */}
+            {job.africa_friendly && (
+              <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs bg-emerald-500/10 border border-emerald-500/20 text-emerald-500 font-semibold">
+                <Globe className="h-3 w-3" />
+                Africa-friendly ✓
+              </span>
+            )}
+
+            {/* Source attribution */}
+            {/* <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono text-muted-foreground bg-muted/50">
+              via {job.source}
+            </span> */}
+
+            {/* Tech tags */}
+            {job.tags.slice(0, 3).map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-mono bg-muted/60 border border-border text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+            {job.tags.length > 4 && (
+              <span className="text-xs text-muted-foreground">+{job.tags.length - 4}</span>
+            )}
+          </div>
+
+          {/* Salary */}
+          <div className="pt-0.5">
+            {salary ? (
+              <span className="inline-flex items-center gap-1 text-sm font-semibold text-foreground">
+                <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
+                {salary}
               </span>
             ) : (
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-primary/10 border border-primary/20 text-primary font-bold">
-                <DollarSign className="h-3 w-3" />
-                {job.currency}
-                {job.salaryMin.toLocaleString()} – {job.currency}
-                {job.salaryMax.toLocaleString()} / {job.period}
-              </span>
+              <span className="text-xs text-muted-foreground">Salary not disclosed</span>
             )}
-
-            {job.isAfricaFriendly && (
-              <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs bg-emerald-500/10 border border-emerald-500/20 text-emerald-600 dark:text-emerald-400 font-bold">
-                <Globe className="h-3 w-3" />
-                Africa-Friendly
-              </span>
-            )}
-
-            <JobTags job={job} />
           </div>
         </div>
       </div>
 
-      <div className="flex flex-row md:flex-col items-center md:items-end justify-between md:justify-center gap-3 w-full md:w-auto shrink-0 pt-4 md:pt-0 border-t md:border-t-0 border-border">
-        <div className="flex items-center gap-1.5 text-xs font-semibold">
-          {renderUrgencyIndicator(job)}
-        </div>
+      {/* Right: urgency + apply */}
+      <div className="flex flex-row md:flex-col items-center md:items-end justify-between md:justify-center gap-3 w-full md:w-auto shrink-0 pt-3 md:pt-0 border-t md:border-t-0 border-border">
+        <UrgencyIndicator job={job} />
 
-        {job.applyUrl && job.isSafeUrl ? (
+        {isSafeUrl ? (
           <a
-            href={job.applyUrl}
+            href={applyUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center font-bold text-sm bg-primary text-primary-foreground hover:bg-primary/95 h-9 rounded-md px-4 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className={[
+              "inline-flex items-center justify-center font-semibold text-sm h-9 rounded-md px-5 transition-colors",
+              isFeatured
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "border border-primary text-primary hover:bg-primary hover:text-primary-foreground",
+            ].join(" ")}
           >
-            Apply
+            Apply →
           </a>
         ) : (
           <button
             disabled
-            className="inline-flex items-center justify-center font-bold text-sm bg-muted text-muted-foreground h-9 rounded-md px-4 shadow-sm cursor-not-allowed opacity-60"
+            className="inline-flex items-center justify-center font-semibold text-sm h-9 rounded-md px-5 bg-muted text-muted-foreground cursor-not-allowed opacity-60"
           >
             Apply
           </button>
@@ -550,471 +337,603 @@ function JobCard({
   );
 }
 
-export default function Jobs() {
-  const [search, setSearch] = useState("");
-  const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
-  const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
-  const [africaFriendly, setAfricaFriendly] = useState(false);
-  const [quickFilters, setQuickFilters] = useState<string[]>([]);
-  const [sortBy, setSortBy] = useState("Newest First");
-  const [visibleCount, setVisibleCount] = useState(12);
-  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
-  const [jobs, setJobs] = useState<Job[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+/** Loading skeleton that matches the JobCard dimensions. */
+function JobCardSkeleton() {
+  return (
+    <div className="flex gap-4 p-5 rounded-xl border border-border bg-card animate-pulse">
+      <div className="w-12 h-12 rounded-lg bg-muted shrink-0" />
+      <div className="flex-1 space-y-3">
+        <div className="h-4 w-2/5 bg-muted rounded" />
+        <div className="h-3 w-3/5 bg-muted rounded" />
+        <div className="flex gap-2">
+          <div className="h-5 w-24 bg-muted rounded-full" />
+          <div className="h-5 w-20 bg-muted rounded-full" />
+          <div className="h-5 w-16 bg-muted rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
 
-  // Capture timestamp via lazy initializer (permitted to be impure at init time, not during render)
-  const [nowMs] = useState<number>(() => Date.now());
+/** Filter panel — rendered both in the sidebar and the mobile sheet. */
+function FilterPanel({
+  filters,
+  onChange,
+  onClear,
+}: {
+  readonly filters: JobFilters;
+  readonly onChange: (patch: Partial<JobFilters>) => void;
+  readonly onClear: () => void;
+}) {
+  const activeCount = countActiveFilters(filters);
 
-  const renderUrgencyIndicator = (job: Job) => {
-    if (job.closingIn === "today") {
-      return (
-        <>
-          <span className="h-2 w-2 rounded-full bg-destructive animate-pulse" />
-          <span className="text-destructive">Closing today</span>
-        </>
-      );
-    }
-    if (job.closingIn) {
-      return (
-        <>
-          <span className="h-2 w-2 rounded-full bg-amber-500" />
-          <span className="text-amber-500">Closes in {job.closingIn}</span>
-        </>
-      );
-    }
-    return (
-      <>
-        <span className="h-2 w-2 rounded-full bg-muted-foreground/60" />
-        <span className="text-muted-foreground">{job.postedAt}</span>
-      </>
-    );
+  const toggleRole = (role: RoleType) => {
+    const next = filters.role_type.includes(role)
+      ? filters.role_type.filter((r) => r !== role)
+      : [...filters.role_type, role];
+    onChange({ role_type: next, page: 1 });
   };
 
-  // Available Filter Options
-  const roleOptions = [
-    "Platform Engineering",
-    "SRE",
-    "Cloud Architect",
-    "Security",
-    "DevOps Engineer",
-    "Sysadmin",
-    "Frontend Engineer",
-    "Backend Engineer",
-  ];
-  const locationOptions = [
-    "Remote (Global)",
-    "Remote (Africa Only)",
-    "Nairobi, KE",
-    "Lagos, NG",
-    "Cape Town, ZA",
-  ];
-
-  // Toggle handlers
-  const handleRoleToggle = (role: string) => {
-    setSelectedRoles((prev) =>
-      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role]
-    );
+  const toggleLocation = (loc: LocationType) => {
+    const next = filters.location_type.includes(loc)
+      ? filters.location_type.filter((l) => l !== loc)
+      : [...filters.location_type, loc];
+    onChange({ location_type: next, page: 1 });
   };
-
-  const handleLocationToggle = (loc: string) => {
-    setSelectedLocations((prev) =>
-      prev.includes(loc) ? prev.filter((l) => l !== loc) : [...prev, loc]
-    );
-  };
-
-  const handleQuickFilterToggle = (filter: string) => {
-    setQuickFilters((prev) =>
-      prev.includes(filter) ? prev.filter((f) => f !== filter) : [...prev, filter]
-    );
-  };
-
-  const clearAllFilters = () => {
-    setSearch("");
-    setSelectedRoles([]);
-    setSelectedLocations([]);
-    setAfricaFriendly(false);
-    setQuickFilters([]);
-  };
-
-  // Filtering & Sorting Logic
-  const filteredJobs = useMemo(() => {
-    const query = search.toLowerCase().trim();
-    return jobs
-      .filter((job) => {
-        if (!matchesSearch(job, query)) return false;
-        if (selectedRoles.length > 0 && !selectedRoles.includes(job.roleType)) return false;
-        if (selectedLocations.length > 0 && !selectedLocations.includes(job.locationTag))
-          return false;
-        if (africaFriendly && !job.isAfricaFriendly) return false;
-        if (!matchesQuickFilters(job, quickFilters)) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        if (sortBy === "Newest First") {
-          return parsePostedAt(a.postedAt, nowMs) - parsePostedAt(b.postedAt, nowMs);
-        } else if (sortBy === "Salary: High to Low") {
-          return b.salaryMax - a.salaryMax;
-        }
-        return 0;
-      });
-  }, [jobs, search, selectedRoles, selectedLocations, africaFriendly, quickFilters, sortBy, nowMs]);
-
-  const closingSoonCount = useMemo(() => {
-    return jobs.filter((job) => {
-      if (!job.closingIn) return false;
-      if (job.closingIn === "today") return true;
-      const days = Number.parseInt(job.closingIn, 10);
-      return !Number.isNaN(days) && days <= 7;
-    }).length;
-  }, [jobs]);
-
-  // Fetch jobs from backend and map to frontend Job type
-  useEffect(() => {
-    let cancelled = false;
-    const fetchJobs = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL ?? ""}/?action=jobs`);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const payload = await res.json();
-        // payload.jobs is expected to be an array of backend job objects
-        const mapped: Job[] = (payload.jobs || []).map(mapBackendJobToFrontendJob);
-        if (!cancelled) {
-          setJobs(mapped);
-        }
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (!cancelled) setError(message);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    fetchJobs();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Sidebar is rendered via FilterSidebar component to keep this function
-  // small and easier to follow.
-
-  // Job list UI is rendered inline in JSX below using JobCard to keep this
-  // component shallow and readable.
 
   return (
-    <div className="min-h-screen bg-background text-foreground transition-colors duration-300">
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border pb-4">
+        <div>
+          <h2 className="text-sm font-bold text-foreground">Filter roles</h2>
+          {activeCount > 0 && <p className="text-xs text-muted-foreground">{activeCount} active</p>}
+        </div>
+        {activeCount > 0 && (
+          <button
+            onClick={onClear}
+            className="text-xs font-semibold text-primary hover:underline focus:outline-none"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Role type */}
+      <div className="space-y-2.5">
+        <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          Role type
+        </span>
+        <div className="space-y-2">
+          {ROLE_OPTIONS.map((role) => {
+            const id = `role-${role.replace(/\s+/g, "-").toLowerCase()}`;
+            return (
+              <label
+                key={role}
+                htmlFor={id}
+                className="flex items-center gap-2.5 text-sm text-foreground cursor-pointer"
+              >
+                <Checkbox
+                  id={id}
+                  checked={filters.role_type.includes(role)}
+                  onCheckedChange={() => toggleRole(role)}
+                  className="border-border data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+                />
+                {role}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Location type */}
+      <div className="space-y-2.5 pt-4 border-t border-border">
+        <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          Location
+        </span>
+        <div className="space-y-2">
+          {LOCATION_OPTIONS.map(({ label, value }) => {
+            const id = `loc-${value}`;
+            return (
+              <label
+                key={value}
+                htmlFor={id}
+                className="flex items-center gap-2.5 text-sm text-foreground cursor-pointer"
+              >
+                <Checkbox
+                  id={id}
+                  checked={filters.location_type.includes(value)}
+                  onCheckedChange={() => toggleLocation(value)}
+                  className="border-border data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+                />
+                {label}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Africa-friendly toggle */}
+      <div className="pt-4 border-t border-border flex items-center justify-between">
+        <div>
+          <span className="text-xs font-bold uppercase tracking-wider text-primary block">
+            Africa-friendly only
+          </span>
+          <span className="text-xs text-muted-foreground">Hires from Africa</span>
+        </div>
+        <Switch
+          checked={filters.africa_friendly}
+          onCheckedChange={(v) => onChange({ africa_friendly: v, page: 1 })}
+          aria-label="Show only Africa-friendly roles"
+          className="data-[state=checked]:bg-primary"
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Pagination controls. */
+function Pagination({
+  page,
+  totalPages,
+  onPage,
+}: {
+  readonly page: number;
+  readonly totalPages: number;
+  readonly onPage: (p: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+
+  // Show at most 5 page numbers centred on current page
+  const range: number[] = [];
+  const start = Math.max(1, page - 2);
+  const end = Math.min(totalPages, start + 4);
+  for (let i = start; i <= end; i++) range.push(i);
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center justify-center gap-1 pt-6">
+      <button
+        onClick={() => onPage(page - 1)}
+        disabled={page === 1}
+        className="px-3 py-1.5 text-sm rounded-md border border-border text-muted-foreground hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >
+        ← Prev
+      </button>
+
+      {start > 1 && (
+        <>
+          <button
+            onClick={() => onPage(1)}
+            className="px-3 py-1.5 text-sm rounded-md border border-border text-muted-foreground hover:bg-accent transition-colors"
+          >
+            1
+          </button>
+          {start > 2 && <span className="px-1 text-muted-foreground">…</span>}
+        </>
+      )}
+
+      {range.map((p) => (
+        <button
+          key={p}
+          onClick={() => onPage(p)}
+          aria-current={p === page ? "page" : undefined}
+          className={[
+            "px-3 py-1.5 text-sm rounded-md border transition-colors",
+            p === page
+              ? "bg-primary text-primary-foreground border-primary font-semibold"
+              : "border-border text-muted-foreground hover:bg-accent",
+          ].join(" ")}
+        >
+          {p}
+        </button>
+      ))}
+
+      {end < totalPages && (
+        <>
+          {end < totalPages - 1 && <span className="px-1 text-muted-foreground">…</span>}
+          <button
+            onClick={() => onPage(totalPages)}
+            className="px-3 py-1.5 text-sm rounded-md border border-border text-muted-foreground hover:bg-accent transition-colors"
+          >
+            {totalPages}
+          </button>
+        </>
+      )}
+
+      <button
+        onClick={() => onPage(page + 1)}
+        disabled={page === totalPages}
+        className="px-3 py-1.5 text-sm rounded-md border border-border text-muted-foreground hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >
+        Next →
+      </button>
+    </nav>
+  );
+}
+
+// ── Page component ────────────────────────────────────────────────────────────
+
+export default function Jobs() {
+  const [filters, setFilters] = useState<JobFilters>(DEFAULT_FILTERS);
+  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
+
+  const { jobs, total, page, totalPages, lastSync, isLoading, isError, setPage } = useJobs(filters);
+
+  // Merge a partial filter patch and always reset to page 1 unless page is
+  // the only thing changing (setPage handles that separately).
+  const patchFilters = useCallback((patch: Partial<JobFilters>) => {
+    setFilters((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters(DEFAULT_FILTERS);
+  }, []);
+
+  const activeFilterCount = countActiveFilters(filters);
+
+  // Stats for the hero bar
+  const totalMembers = statisticsData.find((s) => s.id === "community-members")?.number ?? "4,000+";
+  const totalEvents = statisticsData.find((s) => s.id === "events")?.number ?? "70+";
+
+  const closingSoonCount = jobs.filter(
+    (j) => j.days_remaining !== null && j.days_remaining <= 7
+  ).length;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
       <Seo
-        title="DevOps Jobs"
-        description="Find DevOps, SRE, and Platform Engineering roles suited for African engineers with local and global remote options."
+        title="DevOps Jobs for African Engineers"
+        description="Curated DevOps, SRE, Cloud, and Platform Engineering roles for African engineers. Africa-friendly roles clearly marked. Updated daily."
       />
       <Navbar />
 
-      {/* A. Hero / Header Section */}
-      <section className="bg-accent/40 dark:bg-accent/20 py-16 border-b border-border">
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <section className="bg-accent/30 dark:bg-accent/10 border-b border-border py-14">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
-          {/* Eyebrow Label */}
+          {/* Eyebrow */}
           <p className="text-xs font-mono tracking-widest text-muted-foreground uppercase">
             {"// open roles · updated daily"}
           </p>
 
           {/* Headline */}
-          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-foreground font-sans">
+          <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-foreground">
             DevOps Jobs for African Engineers
           </h1>
 
-          {/* Stats Bar */}
-          <div className="inline-flex flex-wrap md:flex-nowrap items-center justify-center gap-x-4 gap-y-2 bg-ndc-darkblue text-white rounded-full px-6 py-2.5 text-xs md:text-sm font-medium shadow-md">
-            <span>{loading ? "..." : `${jobs.length} open roles`}</span>
-            <span className="hidden md:inline text-white/40">|</span>
-            <span className="text-primary-light-blue font-semibold">
-              {loading ? "..." : `${closingSoonCount} closing this week`}
+          <p className="text-sm text-muted-foreground max-w-xl mx-auto">
+            Curated DevOps, SRE, Cloud, and Platform Engineering roles. Africa-friendly roles
+            clearly marked.
+          </p>
+
+          {/* Stats bar */}
+          <div className="inline-flex flex-wrap items-center justify-center gap-x-4 gap-y-1 bg-ndc-darkblue text-white rounded-full px-6 py-2.5 text-xs font-mono shadow-md">
+            <span className="font-semibold text-primary">
+              {isLoading ? "—" : `${total} open roles`}
             </span>
-            <span className="hidden md:inline text-white/40">|</span>
-            <span className="text-white/80">Updated 2 hours ago</span>
+            <span className="text-white/30 hidden md:inline">|</span>
+            <span className="text-white/70">
+              {closingSoonCount > 0
+                ? `${closingSoonCount} closing this week`
+                : "Updated " + lastSync}
+            </span>
+            <span className="text-white/30 hidden md:inline">|</span>
+            <span className="text-white/50">Updated {lastSync}</span>
           </div>
 
-          {/* Search Bar Row */}
-          <div className="w-full max-w-2xl mx-auto flex flex-col sm:flex-row gap-2.5 pt-4">
+          {/* Search bar */}
+          <div className="w-full max-w-2xl mx-auto flex gap-2.5 pt-2">
             <div className="relative flex-1">
-              <span className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <Search className="h-5 w-5 text-muted-foreground" />
-              </span>
+              <Search className="absolute inset-y-0 left-3 my-auto h-4 w-4 text-muted-foreground pointer-events-none" />
               <input
-                type="text"
-                value={search}
-                onChange={(e) => {
-                  setSearch(e.target.value);
-                  setVisibleCount(12);
-                }}
-                placeholder="Search role, tech stack, or company..."
-                aria-label="Search jobs by role, technology stack, or company"
-                className="w-full pl-10 pr-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background transition-all"
+                type="search"
+                value={filters.q}
+                onChange={(e) => patchFilters({ q: e.target.value, page: 1 })}
+                placeholder="Search roles, companies, or technologies…"
+                aria-label="Search jobs"
+                className="w-full pl-10 pr-10 py-3 bg-card border border-border rounded-lg text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background text-sm transition-all"
               />
+              {filters.q && (
+                <button
+                  onClick={() => patchFilters({ q: "", page: 1 })}
+                  className="absolute inset-y-0 right-3 my-auto text-muted-foreground hover:text-foreground"
+                  aria-label="Clear search"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
             </div>
-            <Button
-              className="bg-primary text-white hover:bg-primary/95 px-6 py-3 h-auto font-bold rounded-lg shadow-sm"
-              onClick={() => setVisibleCount(12)}
-            >
-              Find
+            <Button className="bg-primary text-primary-foreground hover:bg-primary/90 px-6 font-semibold rounded-lg">
+              Search
             </Button>
           </div>
 
-          {/* Quick Filter Row */}
-          <div className="flex flex-wrap items-center justify-center gap-2 pt-2">
-            <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground mr-1">
-              QUICK FILTERS:
-            </span>
-            {["Remote", "Kubernetes", "Senior"].map((filter) => {
-              const isActive = quickFilters.includes(filter);
+          {/* Quick filter pills */}
+          <div className="flex flex-wrap items-center justify-center gap-2 pt-1">
+            {LOCATION_OPTIONS.map(({ label, value }) => {
+              const active = filters.location_type.includes(value);
               return (
                 <button
-                  key={filter}
+                  key={value}
                   onClick={() => {
-                    handleQuickFilterToggle(filter);
-                    setVisibleCount(12);
+                    const next = active
+                      ? filters.location_type.filter((l) => l !== value)
+                      : [...filters.location_type, value];
+                    patchFilters({ location_type: next, page: 1 });
                   }}
-                  className={`px-4 py-1.5 rounded-full text-xs font-semibold tracking-wide border transition-all ${
-                    isActive
-                      ? "bg-primary text-primary-foreground border-primary shadow-sm"
-                      : "border-border text-muted-foreground bg-card hover:bg-accent hover:text-accent-foreground"
-                  }`}
+                  className={[
+                    "px-3.5 py-1.5 rounded-full text-xs font-medium border transition-all",
+                    active
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "border-border text-muted-foreground bg-card hover:bg-accent",
+                  ].join(" ")}
                 >
-                  {filter}
+                  {label}
                 </button>
               );
             })}
+            <button
+              onClick={() => patchFilters({ africa_friendly: !filters.africa_friendly, page: 1 })}
+              className={[
+                "px-3.5 py-1.5 rounded-full text-xs font-medium border transition-all",
+                filters.africa_friendly
+                  ? "bg-emerald-500 text-white border-emerald-500"
+                  : "border-border text-muted-foreground bg-card hover:bg-accent",
+              ].join(" ")}
+            >
+              ✓ Africa-friendly
+            </button>
           </div>
         </div>
       </section>
 
-      {/* B. Main Content Area */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        {/* Mobile Filter Toggle Button */}
-        <div className="flex md:hidden items-center justify-between mb-6">
+      {/* ── Main layout ──────────────────────────────────────────────────── */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        {/* Mobile filter + sort bar */}
+        <div className="flex md:hidden items-center justify-between mb-6 gap-3">
           <Sheet open={isMobileFilterOpen} onOpenChange={setIsMobileFilterOpen}>
             <SheetTrigger asChild>
               <Button variant="outline" className="flex items-center gap-2 bg-card border-border">
                 <SlidersHorizontal className="h-4 w-4" />
-                <span>Filters</span>
-                {(selectedRoles.length > 0 || selectedLocations.length > 0 || africaFriendly) && (
-                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white">
-                    {(selectedRoles.length > 0 ? 1 : 0) +
-                      (selectedLocations.length > 0 ? 1 : 0) +
-                      (africaFriendly ? 1 : 0)}
+                Filters
+                {activeFilterCount > 0 && (
+                  <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white">
+                    {activeFilterCount}
                   </span>
                 )}
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="w-[280px] overflow-y-auto bg-card border-border">
               <SheetHeader className="sr-only">
-                <SheetTitle>Filter Roles</SheetTitle>
+                <SheetTitle>Filter roles</SheetTitle>
                 <SheetDescription>
-                  Filter job roles by type, location, and Africa-friendly criteria
+                  Filter by role type, location, and Africa-friendly criteria
                 </SheetDescription>
               </SheetHeader>
-              <div className="py-4">
-                <FilterSidebar
-                  selectedRoles={selectedRoles}
-                  selectedLocations={selectedLocations}
-                  africaFriendly={africaFriendly}
-                  roleOptions={roleOptions}
-                  locationOptions={locationOptions}
-                  onRoleToggle={handleRoleToggle}
-                  onLocationToggle={handleLocationToggle}
-                  onAfricaToggle={setAfricaFriendly}
-                  onClear={clearAllFilters}
-                />
+              <div className="py-6">
+                <FilterPanel filters={filters} onChange={patchFilters} onClear={clearFilters} />
               </div>
             </SheetContent>
           </Sheet>
 
-          {/* Sort for Mobile */}
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-bold text-muted-foreground uppercase">SORT BY:</span>
-            <div className="relative">
-              <select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value)}
-                aria-label="Sort jobs by"
-                className="bg-card text-foreground border border-border rounded-md pl-3 pr-8 py-1.5 text-sm appearance-none focus:outline-none focus:ring-2 focus:ring-ring"
-              >
-                <option value="Newest First">Newest First</option>
-                <option value="Salary: High to Low">Salary: High to Low</option>
-              </select>
-              <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                <ChevronDown className="h-4 w-4 text-muted-foreground" />
-              </span>
-            </div>
+          {/* Sort (mobile) */}
+          <div className="relative flex items-center gap-2">
+            <label htmlFor="sort-mobile" className="text-xs text-muted-foreground sr-only">
+              Sort
+            </label>
+            <select
+              id="sort-mobile"
+              value={filters.sort}
+              onChange={(e) =>
+                patchFilters({ sort: e.target.value as JobFilters["sort"], page: 1 })
+              }
+              className="bg-card text-foreground border border-border rounded-md pl-3 pr-8 py-1.5 text-sm appearance-none focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {SORT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="absolute right-2 h-4 w-4 text-muted-foreground pointer-events-none" />
           </div>
         </div>
 
-        {/* Desktop Two-Column Layout */}
+        {/* Two-column layout */}
         <div className="flex flex-col lg:flex-row gap-8">
-          {/* Left Sidebar (Desktop & Tablet) */}
+          {/* Sidebar (desktop) */}
           <aside className="hidden md:block w-full lg:w-[220px] shrink-0 lg:sticky lg:top-24 self-start bg-card border border-border rounded-xl p-5 shadow-sm">
-            <FilterSidebar
-              selectedRoles={selectedRoles}
-              selectedLocations={selectedLocations}
-              africaFriendly={africaFriendly}
-              roleOptions={roleOptions}
-              locationOptions={locationOptions}
-              onRoleToggle={handleRoleToggle}
-              onLocationToggle={handleLocationToggle}
-              onAfricaToggle={setAfricaFriendly}
-              onClear={clearAllFilters}
-            />
+            <FilterPanel filters={filters} onChange={patchFilters} onClear={clearFilters} />
           </aside>
 
-          {/* Right Content Area */}
-          <section className="flex-1 space-y-6">
-            {/* Top Bar (Filtered Count & Sort Selector) */}
-            <div className="flex items-center justify-between border-b border-border pb-4">
-              <div className="text-sm uppercase tracking-wide">
-                Showing{" "}
-                <span className="font-bold text-primary text-base">{filteredJobs.length}</span>{" "}
-                <span className="text-muted-foreground font-semibold">Roles</span>
-                {loading && (
-                  <span className="ml-2 text-xs text-muted-foreground">(loading...)</span>
+          {/* Jobs list */}
+          <section className="flex-1 space-y-4" aria-label="Job listings">
+            {/* Top bar: count + sort */}
+            <div className="flex items-center justify-between pb-4 border-b border-border">
+              <p className="text-sm text-muted-foreground">
+                {isLoading ? (
+                  "Loading…"
+                ) : (
+                  <>
+                    <span className="font-bold text-foreground text-base">{total}</span>{" "}
+                    {total === 1 ? "role" : "roles"} found
+                  </>
                 )}
-                {error && <span className="ml-2 text-xs text-destructive">(failed to load)</span>}
-              </div>
+              </p>
+
+              {/* Sort (desktop) */}
               <div className="hidden md:flex items-center gap-2">
-                <span className="text-xs font-bold text-muted-foreground uppercase">SORT BY:</span>
+                <label htmlFor="sort-desktop" className="text-xs text-muted-foreground">
+                  Sort by
+                </label>
                 <div className="relative">
                   <select
-                    value={sortBy}
-                    onChange={(e) => setSortBy(e.target.value)}
-                    aria-label="Sort jobs by"
-                    className="bg-card text-foreground border border-border rounded-md pl-3 pr-8 py-1.5 text-sm appearance-none focus:outline-none focus:ring-2 focus:ring-ring cursor-pointer"
+                    id="sort-desktop"
+                    value={filters.sort}
+                    onChange={(e) =>
+                      patchFilters({ sort: e.target.value as JobFilters["sort"], page: 1 })
+                    }
+                    className="bg-card text-foreground border border-border rounded-md pl-3 pr-8 py-1.5 text-sm appearance-none focus:outline-none focus:ring-2 focus:ring-ring"
                   >
-                    <option value="Newest First">Newest First</option>
-                    <option value="Salary: High to Low">Salary: High to Low</option>
+                    {SORT_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
                   </select>
-                  <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                  </span>
+                  <ChevronDown className="absolute right-2 inset-y-0 my-auto h-4 w-4 text-muted-foreground pointer-events-none" />
                 </div>
               </div>
             </div>
 
-            {/* Job Cards List */}
-            {(() => {
-              if (loading) {
-                return (
-                  <div className="text-center py-16 bg-card border border-border rounded-xl space-y-3">
-                    <p className="text-lg font-medium text-foreground">Loading roles…</p>
-                    <p className="text-sm text-muted-foreground">
-                      Please wait while we fetch the latest jobs.
-                    </p>
-                  </div>
-                );
-              }
+            {/* Loading skeletons */}
+            {isLoading && (
+              <div className="space-y-4">
+                {Array.from({ length: 6 }, (_, i) => `skeleton-${i}`).map((id) => (
+                  <JobCardSkeleton key={id} />
+                ))}
+              </div>
+            )}
 
-              if (error) {
-                return (
-                  <div className="text-center py-16 bg-card border border-border rounded-xl space-y-3">
-                    <p className="text-lg font-medium text-foreground">Failed to load roles</p>
-                    <p className="text-sm text-destructive">{error}</p>
-                    <Button className="mt-2" onClick={() => location.reload()}>
-                      Retry
-                    </Button>
-                  </div>
-                );
-              }
-
-              if (filteredJobs.length === 0) {
-                return (
-                  <div className="text-center py-16 bg-card border border-border rounded-xl space-y-3">
-                    <p className="text-lg font-medium text-foreground">
-                      No roles match your filters
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      Try clearing filters or search to browse all jobs.
-                    </p>
-                    <Button variant="outline" className="mt-2" onClick={clearAllFilters}>
-                      Reset All Filters
-                    </Button>
-                  </div>
-                );
-              }
-
-              return (
-                <div className="space-y-4">
-                  {filteredJobs.slice(0, visibleCount).map((job) => (
-                    <JobCard
-                      key={job.id}
-                      job={job}
-                      renderUrgencyIndicator={renderUrgencyIndicator}
-                    />
-                  ))}
-                </div>
-              );
-            })()}
-
-            {/* Load More Button */}
-            {filteredJobs.length > visibleCount && (
-              <div className="flex justify-center pt-4">
+            {/* Error state */}
+            {!isLoading && isError && (
+              <div className="flex flex-col items-center gap-3 py-16 text-center bg-card border border-border rounded-xl">
+                <AlertCircle className="h-10 w-10 text-destructive/60" />
+                <p className="font-medium text-foreground">Job listings temporarily unavailable</p>
+                <p className="text-sm text-muted-foreground">
+                  Check your connection or try again in a moment.
+                </p>
                 <Button
                   variant="outline"
-                  onClick={() => setVisibleCount((prev) => prev + 3)}
-                  className="w-full sm:w-auto border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground font-mono font-bold tracking-wider"
+                  className="mt-1 gap-2"
+                  onClick={() => patchFilters({ page: 1 })}
                 >
-                  LOAD MORE ROLES
+                  <RefreshCw className="h-4 w-4" />
+                  Retry
                 </Button>
               </div>
+            )}
+
+            {/* Empty state */}
+            {!isLoading && !isError && jobs.length === 0 && (
+              <div className="flex flex-col items-center gap-3 py-16 text-center bg-card border border-border rounded-xl">
+                <Search className="h-10 w-10 text-muted-foreground/40" />
+                <p className="font-medium text-foreground">No roles match your filters</p>
+                <p className="text-sm text-muted-foreground">
+                  Try adjusting your filters or check back tomorrow — we update listings daily.
+                </p>
+                <Button variant="outline" className="mt-1" onClick={clearFilters}>
+                  Clear all filters
+                </Button>
+              </div>
+            )}
+
+            {/* Job cards */}
+            {!isLoading && !isError && jobs.length > 0 && (
+              <>
+                {/* Featured strip */}
+                {jobs.some((j) => j.is_featured) && (
+                  <p className="text-xs font-mono text-primary">⭐ Featured Opportunities</p>
+                )}
+
+                <div className="space-y-3">
+                  {jobs.map((job) => (
+                    <JobCard key={job.id} job={job} />
+                  ))}
+                </div>
+
+                {/* Pagination */}
+                <Pagination
+                  page={page}
+                  totalPages={totalPages}
+                  onPage={(p) => {
+                    setPage(p);
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  }}
+                />
+              </>
             )}
           </section>
         </div>
       </main>
 
-      {/* C. Footer CTA Section */}
-      <section className="bg-ndc-darkblue text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-8">
-          <div className="max-w-3xl mx-auto space-y-3">
-            <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-              Hire DevOps talent across Africa
-            </h2>
-            <p className="text-primary-light-blue text-sm md:text-base leading-relaxed">
-              Connect with our vetted community of SREs, Platform Engineers, and Cloud Architects
-              building the future of infrastructure.
-            </p>
-          </div>
+      {/* ── Employer CTA ─────────────────────────────────────────────────── */}
+      <section className="bg-ndc-darkblue text-white border-t border-white/10 py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col lg:flex-row items-center justify-between gap-10">
+            {/* Left: copy */}
+            <div className="max-w-xl space-y-3 text-center lg:text-left">
+              <p className="text-xs font-mono text-primary uppercase tracking-widest">
+                {"// for employers"}
+              </p>
+              <h2 className="text-2xl md:text-3xl font-bold">Hire DevOps talent across Africa</h2>
+              <p className="text-sm text-white/70 leading-relaxed">
+                Connect with our vetted community of SREs, Platform Engineers, and Cloud Architects.
+                Post a role and reach engineers actively building Africa&apos;s infrastructure.
+              </p>
+              <div className="flex flex-wrap gap-3 justify-center lg:justify-start pt-2">
+                <Button className="bg-primary text-white hover:bg-primary/90 font-semibold px-6">
+                  Post a Job →
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-white/20 text-white hover:bg-white/10 font-medium px-6"
+                >
+                  Learn about featuring
+                </Button>
+              </div>
+            </div>
 
-          {/* Stats Grid */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-4xl mx-auto py-4">
-            <div className="space-y-1">
-              <div className="text-3xl md:text-4xl font-extrabold text-white">
-                {statisticsData.find((s) => s.id === "community-members")?.number || "4,000+"}
+            {/* Right: trust stats */}
+            <div className="grid grid-cols-3 gap-6 text-center shrink-0">
+              <div>
+                <div className="text-3xl font-extrabold text-white">{totalMembers}</div>
+                <div className="text-xs font-bold uppercase tracking-widest text-primary mt-1">
+                  Members
+                </div>
               </div>
-              <div className="text-xs font-bold uppercase tracking-widest text-primary-light-blue">
-                MEMBERS
+              <div>
+                <div className="text-3xl font-extrabold text-white">{totalEvents}</div>
+                <div className="text-xs font-bold uppercase tracking-widest text-primary mt-1">
+                  Events
+                </div>
               </div>
-            </div>
-            <div className="space-y-1">
-              <div className="text-3xl md:text-4xl font-extrabold text-white">
-                {statisticsData.find((s) => s.id === "events")?.number || "70+"}
-              </div>
-              <div className="text-xs font-bold uppercase tracking-widest text-primary-light-blue">
-                EVENTS HOSTED
-              </div>
-            </div>
-            <div className="space-y-1">
-              <div className="text-3xl md:text-4xl font-extrabold text-white">98%</div>
-              <div className="text-xs font-bold uppercase tracking-widest text-primary-light-blue">
-                PLACEMENT RATE
+              <div>
+                <div className="text-3xl font-extrabold text-white">20+</div>
+                <div className="text-xs font-bold uppercase tracking-widest text-primary mt-1">
+                  Partners
+                </div>
               </div>
             </div>
           </div>
-
-          {/* CTA Button */}
-          <Button className="bg-primary text-white hover:bg-primary/95 text-base font-bold px-8 py-6 h-auto rounded-lg shadow-lg">
-            Post a Job Now
-          </Button>
         </div>
       </section>
+
+      {/* ── Notification strip ───────────────────────────────────────────── */}
+      {/* <div className="bg-card border-t border-border py-4">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col sm:flex-row items-center justify-between gap-4">
+          <p className="text-sm font-medium text-foreground">
+            🔔 Get new DevOps jobs delivered daily
+          </p>
+          <div className="flex gap-3">
+            <a
+              href="https://t.me/nairobidevops"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-1.5 rounded-full text-xs font-semibold border border-border text-foreground hover:bg-[#229ED9] hover:text-white hover:border-[#229ED9] transition-colors"
+            >
+              Join Telegram
+            </a>
+            <a
+              href="https://nairobidevops.slack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-4 py-1.5 rounded-full text-xs font-semibold border border-border text-foreground hover:bg-[#4A154B] hover:text-white hover:border-[#4A154B] transition-colors"
+            >
+              Join Slack
+            </a>
+          </div>
+        </div>
+      </div> */}
 
       <Footer />
     </div>


### PR DESCRIPTION
## What does this PR do?

Refactors the Jobs page to use a `useJobs` custom hook backed by the PHP API, replacing client-side filtering with server-side filtering, sorting, and pagination.

## Linked issue

Closes #<!-- issue number -->

## Type of change

- [x] `refactor` — code restructuring (no behaviour change)
- [x] `feat` — new feature or component (server-side pagination, `useJobs` hook)

## What changed?

- Extracted a `useJobs(filters)` hook (`frontend/client/src/hooks/useJobs.ts`) with debounced search, AbortController for stale-request cancellation, and automatic page-reset on filter changes
- Replaced ad-hoc `fetch` + `useMemo` filtering in `jobs.tsx` with `useJobs` + a `patchFilters` helper
- Replaced `FilterSidebar` with a new `FilterPanel` component driven by typed `JobFilters`
- Replaced "load more" infinite-scroll pattern with a proper `<Pagination />` component (server-side pages)
- Quick-filter pills now map to real `location_type` API params; added an Africa-friendly toggle pill
- Hero stats bar shows live total count and last-sync timestamp from the API response
- Loading state uses skeleton cards instead of a spinner; error state includes a Retry button
- Employer CTA section restructured to two-column layout with trust stats
- Moved `backend/cron/` scripts into `backend/cron/works/` subdirectory
- Updated SEO title and description for the Jobs page

## Screenshots

### Before

<!-- Screenshot of old Jobs page -->

### After

<!-- Screenshot of new Jobs page -->

### Breakpoints tested

- [ ] Mobile — 375px
- [ ] Tablet — 768px
- [ ] Desktop — 1280px
- [ ] Wide — 1536px+

## How was this tested?

- Verified filter changes (role type, location type, Africa-friendly, search) all reset to page 1 and fire new API requests
- Confirmed stale requests are cancelled when filters change rapidly (network tab)
- Ran `npm run build` from `frontend/` — no TypeScript or build errors
- Checked pagination renders correctly at page boundaries (first page, last page, mid-range)
- Verified error state displays with retry when API is unreachable
- Verified loading skeletons display during fetch

## Pre-submission checklist

- [ ] `npm run format` has been run from `frontend/`
- [ ] `npm run build` passes with no errors
- [ ] `npm run lint` passes with no new warnings
- [ ] `npm run typecheck` passes
- [ ] No `console.log` or debug artifacts (note: `console.error` in `useJobs` is intentional for API errors)
- [ ] Branch is up to date with `main`
- [ ] PR title follows Conventional Commits format

## Notes for reviewers

- `FilterPanel` component is referenced in the diff but lives outside this diff — confirm it exists or needs to be added
- The notification strip (Telegram/Slack) is commented out in the new code — left as a follow-up
- The `works/` reorganisation for cron scripts is a minor housekeeping change; no logic was altered

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/354)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Jobs page to use a new `useJobs` hook backed by the PHP API, moving filtering, sorting (including salary), and pagination to the server for faster, more accurate results. Adds We Work Remotely sync and shared salary parsing with improved period detection and stronger regex extraction for more reliable salary display and sorting.

- **New Features**
  - Introduced `useJobs` with debounced search, request cancellation, and auto page reset on filter changes.
  - Server-side filters and sort (`salary_desc`) with proper `<Pagination />`.
  - New `FilterPanel` with typed `JobFilters`, Africa-friendly toggle, and quick-location pills.
  - Improved UX: loading skeletons, error state with Retry, and hero stats with live totals.

- **Refactors**
  - Replaced client filtering in `jobs.tsx` with `useJobs` and a simple `patchFilters` helper.
  - Centralized salary helpers in `backend/helpers.php` used by Remotive and WWR; added a WWR description-based salary extractor.
  - Moved cron scripts to `backend/cron/works/`, fixed bootstrap paths, and updated Jobs page SEO.

<sup>Written for commit 7f80c38b15fa2324f98f79bc6daae839c7fa1335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

