### PR TITLE
fix(backend): add charset, index, and schema flexibility migration

### DIFF
--- a/backend/migrations/001_charset_and_index_fixes.sql
+++ b/backend/migrations/001_charset_and_index_fixes.sql
@@ -1,23 +1,19 @@
 -- ============================================================================
 -- Migration: 001_charset_and_index_fixes.sql
--- Purpose:   Fix charset inconsistency, ENUM fragility, and missing indexes
+-- Purpose:   Fix charset inconsistency, ENUM fragility, and correct indexes
 --            ahead of adding new job source APIs.
 --
--- Run this IDENTICALLY against: local -> staging -> production.
--- Safe to re-run: ALTER TABLE ... MODIFY / CONVERT statements are idempotent
--- in effect (re-applying them is a no-op if already applied), but the
--- ADD INDEX / ADD COLUMN statements will error on a second run unless you
--- guard them (see notes at bottom). Run once per environment and verify.
+-- Compatible with: MySQL 5.7, 8.0, 8.4, 9.x
+-- Run against:     local -> staging -> production (in that order)
 -- ============================================================================
 
+
 -- ----------------------------------------------------------------------------
--- 1. CHARSET FIXES
--- `jobs` already has utf8mb4 set explicitly. These three tables do not and
--- will have inherited whatever the server/database default was at creation
--- time (often latin1 or 3-byte utf8 on cPanel). Converting now prevents
--- silent truncation/corruption when non-Latin or emoji text (job titles,
--- error messages, message previews) gets inserted from new sources.
+-- 1. CHARSET FIXES — all four tables to utf8mb4_unicode_ci
 -- ----------------------------------------------------------------------------
+
+ALTER TABLE jobs
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 ALTER TABLE sync_log
   CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -30,11 +26,9 @@ ALTER TABLE job_clicks
 
 
 -- ----------------------------------------------------------------------------
--- 2. WIDEN `sync_log.source` FROM ENUM TO VARCHAR
--- This is a log table, not a dedup anchor (jobs.source is, and stays ENUM
--- below) -- there's no integrity benefit to constraining it, and every new
--- API source means a forgotten ALTER here breaks logging for that source's
--- failures silently, which is the opposite of what sync_log is for.
+-- 2. WIDEN sync_log.source FROM ENUM TO VARCHAR
+-- Log tables must never require a schema migration just to accept a new
+-- source name — that would silently break failure logging for new sources.
 -- ----------------------------------------------------------------------------
 
 ALTER TABLE sync_log
@@ -42,10 +36,9 @@ ALTER TABLE sync_log
 
 
 -- ----------------------------------------------------------------------------
--- 3. WIDEN `notifications_log.channel` FROM ENUM TO VARCHAR
--- Same reasoning -- you already added 'discord' once since the original
--- design. Next channel (whatsapp, linkedin, twitter per the PRD Phase 2
--- list) should not require a schema migration just to log a send attempt.
+-- 3. WIDEN notifications_log.channel FROM ENUM TO VARCHAR
+-- Same reasoning — new channels (whatsapp, linkedin, twitter) should not
+-- require a migration just to log a send attempt.
 -- ----------------------------------------------------------------------------
 
 ALTER TABLE notifications_log
@@ -53,45 +46,66 @@ ALTER TABLE notifications_log
 
 
 -- ----------------------------------------------------------------------------
--- 4. COMPOSITE INDEXES ON `jobs` FOR THE HOT QUERY PATH
--- get_jobs.php always filters WHERE is_active=1 AND is_approved=1, then
--- sorts by posted_at DESC (newest) or closes_at ASC (closing soon).
--- Single-column indexes force MySQL to pick one and filesort the rest.
--- There is currently no index on is_approved at all despite it being in
--- every query's WHERE clause.
+-- 4. DROP OLD INCORRECT INDEXES
+-- Written without IF EXISTS for MySQL 5.7/8.0 compatibility.
+-- These will error if the indexes don't exist — that is safe to ignore,
+-- MySQL continues executing the rest of the file.
 -- ----------------------------------------------------------------------------
 
-ALTER TABLE jobs
-  ADD INDEX idx_active_approved_posted (is_active, is_approved, posted_at);
-
-ALTER TABLE jobs
-  ADD INDEX idx_active_approved_closes (is_active, is_approved, closes_at);
+ALTER TABLE jobs DROP INDEX idx_active_approved_posted;
+ALTER TABLE jobs DROP INDEX idx_active_approved_closes;
 
 
 -- ----------------------------------------------------------------------------
--- 5. ADD `click_type` TO `job_clicks`
--- PRD distinguishes 'apply' vs 'affiliate_apply' clicks for revenue
--- reporting, but the table as built only records that a click happened.
--- Adding now avoids click data you can't retroactively categorise later.
+-- 5. GENERATED COLUMN FOR NULL-SAFE closes_at SORTING
+-- Jobs with no deadline have closes_at = NULL. A plain index on closes_at
+-- cannot sort NULLs predictably for "closing soon" ORDER BY.
+-- This generated column substitutes a far-future sentinel so every row
+-- has a real sortable value. VIRTUAL = no extra disk storage.
+-- Written without IF NOT EXISTS for MySQL 5.7/8.0 compatibility.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE jobs
+  ADD COLUMN closes_at_sort DATETIME
+    GENERATED ALWAYS AS (IFNULL(closes_at, '2099-12-31 23:59:59')) VIRTUAL;
+
+
+-- ----------------------------------------------------------------------------
+-- 6. CORRECT COMPOSITE INDEXES MATCHING ACTUAL QUERY PATTERNS
+--
+-- get_jobs.php hot path:
+--   WHERE is_active = 1 AND is_approved = 1
+--   ORDER BY is_featured DESC, posted_at DESC    (newest sort)
+--   ORDER BY is_featured DESC, closes_at_sort ASC (closing soon sort)
+--
+-- is_featured must be in the index before posted_at/closes_at_sort
+-- so MySQL can avoid a filesort on the ORDER BY clause.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE jobs
+  ADD INDEX idx_listing_newest (is_active, is_approved, is_featured, posted_at);
+
+ALTER TABLE jobs
+  ADD INDEX idx_listing_closing (is_active, is_approved, is_featured, closes_at_sort);
+
+
+-- ----------------------------------------------------------------------------
+-- 7. click_type COLUMN ON job_clicks
+-- Written without IF NOT EXISTS for MySQL 5.7/8.0 compatibility.
+-- Will error if column already exists (local dev created it this way) —
+-- safe to ignore, the column is already correct in that case.
 -- ----------------------------------------------------------------------------
 
 ALTER TABLE job_clicks
-  ADD COLUMN click_type ENUM('apply','affiliate_apply') NOT NULL DEFAULT 'apply' AFTER job_id;
+  ADD COLUMN click_type
+    ENUM('apply','affiliate_apply') NOT NULL DEFAULT 'apply'
+    AFTER job_id;
 
 
 -- ============================================================================
--- NOT included in this migration (deliberately deferred):
---
--- - jobs.source stays ENUM (it's the dedup anchor, the constraint earns its
---   keep there) -- but remember: adding a new source still requires
---   ALTER TABLE jobs MODIFY source ENUM('remotive','weworkremotely','manual',
---   'employer_submission','NEW_SOURCE_HERE') NOT NULL;
---   as its own migration file when that day comes.
---
--- - source_id NOT NULL fragility for source='manual'/'employer_submission'
---   (synthetic ID generation at insert time, not a schema change) -- handle
---   in application code, separate task.
---
--- - FULLTEXT index on (title, company, description) for search -- not
---   urgent at current row counts, revisit when LIKE search measurably slows.
+-- REMINDER: Adding a new job source requires a new migration file:
+--   migrations/002_add_source_<name>.sql
+-- containing:
+--   ALTER TABLE jobs MODIFY source
+--     ENUM('remotive','weworkremotely','manual','employer_submission','<new>') NOT NULL;
 -- ============================================================================

--- a/backend/migrations/001_charset_and_index_fixes.sql
+++ b/backend/migrations/001_charset_and_index_fixes.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- Migration: 001_charset_and_index_fixes.sql
+-- Purpose:   Fix charset inconsistency, ENUM fragility, and missing indexes
+--            ahead of adding new job source APIs.
+--
+-- Run this IDENTICALLY against: local -> staging -> production.
+-- Safe to re-run: ALTER TABLE ... MODIFY / CONVERT statements are idempotent
+-- in effect (re-applying them is a no-op if already applied), but the
+-- ADD INDEX / ADD COLUMN statements will error on a second run unless you
+-- guard them (see notes at bottom). Run once per environment and verify.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. CHARSET FIXES
+-- `jobs` already has utf8mb4 set explicitly. These three tables do not and
+-- will have inherited whatever the server/database default was at creation
+-- time (often latin1 or 3-byte utf8 on cPanel). Converting now prevents
+-- silent truncation/corruption when non-Latin or emoji text (job titles,
+-- error messages, message previews) gets inserted from new sources.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE sync_log
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE notifications_log
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE job_clicks
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. WIDEN `sync_log.source` FROM ENUM TO VARCHAR
+-- This is a log table, not a dedup anchor (jobs.source is, and stays ENUM
+-- below) -- there's no integrity benefit to constraining it, and every new
+-- API source means a forgotten ALTER here breaks logging for that source's
+-- failures silently, which is the opposite of what sync_log is for.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE sync_log
+  MODIFY source VARCHAR(50) NOT NULL;
+
+
+-- ----------------------------------------------------------------------------
+-- 3. WIDEN `notifications_log.channel` FROM ENUM TO VARCHAR
+-- Same reasoning -- you already added 'discord' once since the original
+-- design. Next channel (whatsapp, linkedin, twitter per the PRD Phase 2
+-- list) should not require a schema migration just to log a send attempt.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE notifications_log
+  MODIFY channel VARCHAR(50) NOT NULL;
+
+
+-- ----------------------------------------------------------------------------
+-- 4. COMPOSITE INDEXES ON `jobs` FOR THE HOT QUERY PATH
+-- get_jobs.php always filters WHERE is_active=1 AND is_approved=1, then
+-- sorts by posted_at DESC (newest) or closes_at ASC (closing soon).
+-- Single-column indexes force MySQL to pick one and filesort the rest.
+-- There is currently no index on is_approved at all despite it being in
+-- every query's WHERE clause.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE jobs
+  ADD INDEX idx_active_approved_posted (is_active, is_approved, posted_at);
+
+ALTER TABLE jobs
+  ADD INDEX idx_active_approved_closes (is_active, is_approved, closes_at);
+
+
+-- ----------------------------------------------------------------------------
+-- 5. ADD `click_type` TO `job_clicks`
+-- PRD distinguishes 'apply' vs 'affiliate_apply' clicks for revenue
+-- reporting, but the table as built only records that a click happened.
+-- Adding now avoids click data you can't retroactively categorise later.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE job_clicks
+  ADD COLUMN click_type ENUM('apply','affiliate_apply') NOT NULL DEFAULT 'apply' AFTER job_id;
+
+
+-- ============================================================================
+-- NOT included in this migration (deliberately deferred):
+--
+-- - jobs.source stays ENUM (it's the dedup anchor, the constraint earns its
+--   keep there) -- but remember: adding a new source still requires
+--   ALTER TABLE jobs MODIFY source ENUM('remotive','weworkremotely','manual',
+--   'employer_submission','NEW_SOURCE_HERE') NOT NULL;
+--   as its own migration file when that day comes.
+--
+-- - source_id NOT NULL fragility for source='manual'/'employer_submission'
+--   (synthetic ID generation at insert time, not a schema change) -- handle
+--   in application code, separate task.
+--
+-- - FULLTEXT index on (title, company, description) for search -- not
+--   urgent at current row counts, revisit when LIKE search measurably slows.
+-- ============================================================================

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,3 +1,13 @@
+-- ============================================================================
+-- schema.sql — NairobiDevOps Jobs Board
+-- Baseline schema for fresh installs.
+-- Always kept in sync with the latest migration in backend/migrations/.
+-- Last updated by: migrations/001_charset_and_index_fixes.sql
+--
+-- Fresh install:  mysql -u root -p <dbname> < backend/schema.sql
+-- Existing install: run migrations/00N_*.sql files in order instead.
+-- ============================================================================
+
 CREATE TABLE IF NOT EXISTS jobs (
     id                  INT PRIMARY KEY AUTO_INCREMENT,
     title               VARCHAR(255) NOT NULL,
@@ -11,77 +21,102 @@ CREATE TABLE IF NOT EXISTS jobs (
     role_type           VARCHAR(100),
     location_type       ENUM('africa_remote','africa_onsite','international_remote'),
     location_detail     VARCHAR(255),
-    africa_friendly     TINYINT(1) DEFAULT 0,
+    africa_friendly     TINYINT(1)   DEFAULT 0,
     salary_min          INT UNSIGNED,
     salary_max          INT UNSIGNED,
-    salary_currency     VARCHAR(10) DEFAULT 'USD',
+    salary_currency     VARCHAR(10)  DEFAULT 'USD',
     salary_period       ENUM('monthly','annual'),
     experience_level    ENUM('junior','mid','senior','lead','any'),
     posted_at           DATETIME,
-    fetched_at          DATETIME DEFAULT CURRENT_TIMESTAMP,
+    fetched_at          DATETIME     DEFAULT CURRENT_TIMESTAMP,
     closes_at           DATETIME,
-    is_active           TINYINT(1) DEFAULT 1,
-    is_featured         TINYINT(1) DEFAULT 0,
+
+    -- Generated column: substitutes a far-future sentinel for NULL so
+    -- "closing soon" ORDER BY closes_at_sort ASC works cleanly on an
+    -- index without NULLs floating to the wrong end of the sort.
+    closes_at_sort      DATETIME
+                          GENERATED ALWAYS AS
+                          (IFNULL(closes_at, '2099-12-31 23:59:59')) VIRTUAL,
+
+    is_active           TINYINT(1)   DEFAULT 1,
+    is_featured         TINYINT(1)   DEFAULT 0,
     featured_until      DATETIME,
-    is_approved         TINYINT(1) DEFAULT 1,
-    is_notified         TINYINT(1) DEFAULT 0,
+    is_approved         TINYINT(1)   DEFAULT 1,
+    is_notified         TINYINT(1)   DEFAULT 0,
     tags                JSON,
-    created_at          DATETIME DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    created_at          DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
-    UNIQUE KEY unique_source_job (source, source_id),
-    INDEX idx_is_active   (is_active),
-    INDEX idx_closes_at   (closes_at),
-    INDEX idx_location    (location_type),
-    INDEX idx_role        (role_type),
-    INDEX idx_notified    (is_notified),
-    INDEX idx_fetched     (fetched_at)
-  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    -- Deduplication anchor: same job from the same source is never inserted twice
+    UNIQUE KEY  unique_source_job      (source, source_id),
 
-  CREATE TABLE IF NOT EXISTS sync_log (
+    -- Hot path: WHERE is_active=1 AND is_approved=1 ORDER BY is_featured DESC, posted_at DESC
+    INDEX idx_listing_newest           (is_active, is_approved, is_featured, posted_at),
+
+    -- Hot path: WHERE is_active=1 AND is_approved=1 ORDER BY is_featured DESC, closes_at_sort ASC
+    INDEX idx_listing_closing          (is_active, is_approved, is_featured, closes_at_sort),
+
+    -- Supporting indexes for individual filter columns
+    INDEX idx_location                 (location_type),
+    INDEX idx_role                     (role_type),
+    INDEX idx_closes_at                (closes_at),
+    INDEX idx_fetched                  (fetched_at),
+    INDEX idx_notified                 (is_notified)
+
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ============================================================================
+-- sync_log: one row per cron run, per source.
+-- source is VARCHAR not ENUM -- new sources must never require a schema
+-- migration just to be able to log their sync results.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS sync_log (
     id            INT PRIMARY KEY AUTO_INCREMENT,
-    source        ENUM('remotive','weworkremotely','manual','employer_submission','expire') NOT NULL,
-    ran_at        DATETIME DEFAULT CURRENT_TIMESTAMP,
-    jobs_fetched  INT DEFAULT 0,
-    jobs_inserted INT DEFAULT 0,
-    jobs_skipped  INT DEFAULT 0,
-    jobs_expired  INT DEFAULT 0,
-    jobs_purged   INT DEFAULT 0,
+    source        VARCHAR(50)  NOT NULL,
+    ran_at        DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    jobs_fetched  INT          DEFAULT 0,
+    jobs_inserted INT          DEFAULT 0,
+    jobs_skipped  INT          DEFAULT 0,
+    jobs_expired  INT          DEFAULT 0,
+    jobs_purged   INT          DEFAULT 0,
     duration_sec  INT,
     errors        TEXT
-  );
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-  CREATE TABLE IF NOT EXISTS notifications_log (
+
+-- ============================================================================
+-- notifications_log: one row per channel per send attempt.
+-- channel is VARCHAR not ENUM -- new channels (whatsapp, linkedin, twitter)
+-- must never require a schema migration just to log a send attempt.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS notifications_log (
     id                INT PRIMARY KEY AUTO_INCREMENT,
-    channel           ENUM('telegram','slack','discord','whatsapp','twitter','linkedin') NOT NULL,
+    channel           VARCHAR(50)  NOT NULL,
     notification_type ENUM('daily_digest','weekly_roundup','instant_alert') NOT NULL,
     job_ids           JSON,
     message_preview   TEXT,
-    sent_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
+    sent_at           DATETIME     DEFAULT CURRENT_TIMESTAMP,
     status            ENUM('sent','failed') NOT NULL,
     error             TEXT
-  );
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-  CREATE TABLE IF NOT EXISTS job_clicks (
-    id         INT PRIMARY KEY AUTO_INCREMENT,
-    job_id     INT NOT NULL,
-    clicked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    INDEX idx_job_id    (job_id),
-    INDEX idx_clicked   (clicked_at),
+-- ============================================================================
+-- job_clicks: fire-and-forget click tracking for affiliate revenue reporting.
+-- click_type distinguishes organic Apply clicks from affiliate Apply clicks.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS job_clicks (
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    job_id      INT          NOT NULL,
+    click_type  ENUM('apply','affiliate_apply') NOT NULL DEFAULT 'apply',
+    clicked_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_job_id  (job_id),
+    INDEX idx_clicked (clicked_at),
     FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
-  );
 
--- ── Migration ──────────────────────────────────────────────────────────────────
--- Existing deployments need the following ALTER TABLE statements:
---
--- 1. sync_log.source: add 'expire' value used by expire_jobs.php:
---
---   ALTER TABLE sync_log
---     MODIFY COLUMN source ENUM('remotive','weworkremotely','manual','employer_submission','expire') NOT NULL;
---
--- 2. notifications_log.channel: add 'discord' (and other newer channels):
---
---   ALTER TABLE notifications_log
---     MODIFY COLUMN channel ENUM('telegram','slack','discord','whatsapp','twitter','linkedin') NOT NULL;
---
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## What
Adds a database migration (`001_charset_and_index_fixes.sql`) to address charset
inconsistency, ENUM fragility, and missing indexes ahead of new job source API
integration.

## Changes
- **Charset**: Convert `sync_log`, `notifications_log`, `job_clicks` → utf8mb4_unicode_ci
- **Schema**: Widen `sync_log.source` and `notifications_log.channel` from ENUM → VARCHAR(50)
- **Performance**: Add composite indexes on `jobs` for `is_active + is_approved + posted_at/closes_at`
- **Feature**: Add `click_type` ENUM column to `job_clicks` for apply vs affiliate tracking

## Why
New job sources (Remotive, WwR, employer submissions) will insert non-Latin text
and emoji. Without utf8mb4, this causes silent truncation. The current ENUM columns
break logging every time a new source/channel is added. Missing indexes force
filesorts on every job listing query.

## Testing
- Run migration against local DB and verify no errors
- Re-run to confirm idempotent behavior (ALTER statements)
- Verify indexes exist: `SHOW INDEX FROM jobs`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/356)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a migration to standardize utf8mb4 across key tables, replace brittle ENUMs in logs, add a null-safe closing sort with corrected composite indexes, and track click type. Prepares the DB for new job sources and avoids truncation, filesorts, and logging breaks.

- **Migration**
  - Convert `jobs`, `sync_log`, `notifications_log`, `job_clicks` to utf8mb4_unicode_ci.
  - Change `sync_log.source` and `notifications_log.channel` from ENUM to VARCHAR(50).
  - Add `closes_at_sort` generated column and composite indexes: `(is_active, is_approved, is_featured, posted_at)` and `(is_active, is_approved, is_featured, closes_at_sort)`; drop old indexes.
  - Add `click_type` ENUM (`apply`, `affiliate_apply`) to `job_clicks` with default `apply`.

<sup>Written for commit 19d6275572b52c628bb4e351cdf33444b9223731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

