### PR TITLE
feat(backend): add job fetcher architecture, migration runner, and PS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,34 +121,41 @@ The frontend dev server runs at `http://localhost:5173`.
 ### Backend Setup
 
 1. **Install dependencies:**
+
    ```bash
    cd backend
    composer install
    ```
 
 2. **Configure environment:**
+
    ```bash
    cp config.example.php config.local.php
    ```
+
    Edit `config.local.php` and update `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS` for your local MySQL setup.
 
 3. **Create database and import schema:**
+
    ```bash
    mysql -u root -p -e "CREATE DATABASE IF NOT EXISTS nairobidevops_jobs_local;"
    mysql -u root -p nairobidevops_jobs_local < schema.sql
    ```
 
 4. **Verify database connection:**
+
    ```bash
    php backend/check_db.php
    ```
 
 5. **Start the development server:**
+
    ```bash
    php -S localhost:8000
    ```
 
 6. **Test the API:**
+
    ```
    http://localhost:8000/?action=jobs
    ```
@@ -197,7 +204,7 @@ The frontend dev server runs at `http://localhost:5173`.
 
 ## Testing
 
-### Frontend
+### Frontend Tests
 
 Tests use **Vitest**. Run from the `frontend/` directory:
 
@@ -208,7 +215,7 @@ npm run test:coverage   # With coverage report
 npm run test:ui         # Vitest UI dashboard
 ```
 
-### Backend
+### Backend Tests
 
 Tests use **PHPUnit**. Run from the `backend/` directory:
 
@@ -223,18 +230,19 @@ The test suite uses a dedicated database (`nairobidevops_jobs_test` — configur
 
 ## Code Quality
 
-### Frontend
+### Frontend Code Quality
 
 - **ESLint** — configured in `frontend/eslint.config.js`
 - **Prettier** — configured in `frontend/.prettierrc`
 - **TypeScript** — strict mode in `frontend/tsconfig.json`
 
 Run all checks together:
+
 ```bash
 cd frontend && npm run check
 ```
 
-### Backend
+### Backend Code Quality
 
 - **PHP-CS-Fixer** — PSR-12 rules with additional conventions (configured in `backend/.php-cs-fixer.php`)
 
@@ -251,10 +259,12 @@ composer format         # Auto-fix style issues
 The project uses GitHub Actions for deployment. See the [Deployment Guide](./docs/frontend/DEPLOYMENT-GUIDE.md) and [deployment documentation](./docs/frontend/deployment.md) for workflow details.
 
 **Deployment environments:**
+
 - **Production**: `main` branch → cPanel (nairobidevops.org)
 - **Staging**: feature/bugfix branches → cPanel subdomain
 
 **Security features:**
+
 - Atomic symlink-based releases with zero-downtime rollback
 - Shared secret store outside web root (`~/config/secrets.env.php`)
 - IP-based rate limiting and origin validation

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "proprietary",
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.4.0 <8.5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -14,20 +14,29 @@
         "files": [
             "helpers.php",
             "db.php"
-        ]
+        ],
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     },
     "scripts": {
         "format": "@php vendor/bin/php-cs-fixer fix",
         "format:check": "@php vendor/bin/php-cs-fixer fix --dry-run --diff",
         "test": "@php vendor/bin/phpunit",
         "test:coverage": "@php vendor/bin/phpunit --coverage-html coverage",
+        "migrate": "@php cron/migrate.php",
         "audit": "@composer audit"
     },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true,
         "platform": {
-            "php": "8.5.7"
+            "php": ">=8.4.0 <8.5.0"
         }
     }
 }

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "proprietary",
     "require": {
-        "php": ">=8.4.0 <8.5.0"
+        "php": ">=8.4.0 <8.6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -36,7 +36,7 @@
         "optimize-autoloader": true,
         "sort-packages": true,
         "platform": {
-            "php": ">=8.4.0 <8.5.0"
+            "php": "8.5.7"
         }
     }
 }

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94a3bbc7ee5162bd6abfe748f9a19b19",
+    "content-hash": "84667d3eb7dfafe74376a096621ff63d",
     "packages": [],
     "packages-dev": [
         {
@@ -2984,16 +2984,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a"
+                "reference": "b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d",
+                "reference": "b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d",
                 "shasum": ""
             },
             "require": {
@@ -3060,7 +3060,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.0"
+                "source": "https://github.com/symfony/console/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -3080,20 +3080,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-16T12:55:20+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -3131,7 +3131,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3151,20 +3151,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
@@ -3217,7 +3217,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -3237,20 +3237,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -3297,7 +3297,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3317,7 +3317,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -3392,16 +3392,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "58d2e767a66052c1487356f953445634a8194c64"
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/58d2e767a66052c1487356f953445634a8194c64",
-                "reference": "58d2e767a66052c1487356f953445634a8194c64",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
                 "shasum": ""
             },
             "require": {
@@ -3436,7 +3436,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.1.0"
+                "source": "https://github.com/symfony/finder/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -3456,7 +3456,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-27T09:05:56+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -4255,16 +4255,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -4318,7 +4318,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4338,7 +4338,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -4553,7 +4553,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": ">=8.4.0 <8.6.0"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/backend/cron/migrate.php
+++ b/backend/cron/migrate.php
@@ -6,10 +6,15 @@ require_once \dirname(__DIR__) . '/vendor/autoload.php';
 
 use App\Migration\MigrationRunner;
 
-$runner = new MigrationRunner(getDB(), \dirname(__DIR__) . '/migrations');
-$runner->ensureMigrationsTableExists();
+try {
+    $runner = new MigrationRunner(getDB(), \dirname(__DIR__) . '/migrations');
+    $runner->ensureMigrationsTableExists();
 
-$pending = $runner->pendingMigrations();
+    $pending = $runner->pendingMigrations();
+} catch (RuntimeException $e) {
+    echo 'FAILED: ' . $e->getMessage() . "\n";
+    exit(1);
+}
 
 if (empty($pending)) {
     echo "No pending migrations.\n";

--- a/backend/cron/migrate.php
+++ b/backend/cron/migrate.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once \dirname(__DIR__) . '/vendor/autoload.php';
+
+use App\Migration\MigrationRunner;
+
+$runner = new MigrationRunner(getDB(), \dirname(__DIR__) . '/migrations');
+$runner->ensureMigrationsTableExists();
+
+$pending = $runner->pendingMigrations();
+
+if (empty($pending)) {
+    echo "No pending migrations.\n";
+    exit(0);
+}
+
+foreach ($pending as $version => $filepath) {
+    echo "Applying {$version}: " . basename($filepath) . "...\n";
+
+    try {
+        $runner->apply($version, $filepath);
+        echo "  done\n";
+    } catch (RuntimeException $e) {
+        echo '  FAILED: ' . $e->getMessage() . "\n";
+        exit(1);
+    }
+}
+
+echo "All migrations applied.\n";

--- a/backend/cron/works/expire_jobs.php
+++ b/backend/cron/works/expire_jobs.php
@@ -49,8 +49,8 @@ $expired = $stmt->rowCount();
 $duration = (int) round((microtime(true) - $startTime) * 1000); // ms
 
 $db->prepare("
-    INSERT INTO sync_log (source, jobs_expired, duration_sec, errors)
-    VALUES ('expire', :expired, :duration, NULL)
+    INSERT INTO sync_log (source, jobs_expired, duration_sec, errors, status)
+    VALUES ('expire', :expired, :duration, NULL, 'success')
 ")->execute([
     ':expired'  => $expired,
     ':duration' => $duration,

--- a/backend/cron/works/sync_remotive.php
+++ b/backend/cron/works/sync_remotive.php
@@ -229,9 +229,9 @@ $errorsStr = empty($errors) ? null : implode(' | ', \array_slice($errors, 0, 10)
 
 $log = $db->prepare("
     INSERT INTO sync_log
-        (source, jobs_fetched, jobs_inserted, jobs_skipped, duration_sec, errors)
+        (source, jobs_fetched, jobs_inserted, jobs_skipped, duration_sec, errors, status)
     VALUES
-        ('remotive', :fetched, :inserted, :skipped, :duration, :errors)
+        ('remotive', :fetched, :inserted, :skipped, :duration, :errors, :status)
 ");
 $log->execute([
     ':fetched'  => $totalFetched,
@@ -239,6 +239,7 @@ $log->execute([
     ':skipped'  => $totalSkipped,
     ':duration' => $duration,
     ':errors'   => $errorsStr,
+    ':status'   => empty($errors) ? 'success' : 'partial',
 ]);
 
 // ── Output (visible when run manually via CLI) ────────────────────────────────

--- a/backend/cron/works/sync_wwremote.php
+++ b/backend/cron/works/sync_wwremote.php
@@ -750,14 +750,15 @@ $duration  = time() - $startTime;
 $errorText = empty($errors) ? null : implode("\n", $errors);
 
 $db->prepare("
-    INSERT INTO sync_log (source, jobs_fetched, jobs_inserted, jobs_skipped, duration_sec, errors)
-    VALUES ('weworkremotely', :fetched, :inserted, :skipped, :duration, :errors)
+    INSERT INTO sync_log (source, jobs_fetched, jobs_inserted, jobs_skipped, duration_sec, errors, status)
+    VALUES ('weworkremotely', :fetched, :inserted, :skipped, :duration, :errors, :status)
 ")->execute([
     ':fetched'  => $totalFetched,
     ':inserted' => $totalInserted,
     ':skipped'  => $totalSkipped + $totalExcluded,
     ':duration' => $duration,
     ':errors'   => $errorText,
+    ':status'   => empty($errors) ? 'success' : 'partial',
 ]);
 
 // ── Summary ───────────────────────────────────────────────────────────────────

--- a/backend/migrations/001_initial_schema.sql
+++ b/backend/migrations/001_initial_schema.sql
@@ -1,0 +1,344 @@
+-- 001_initial_schema.sql
+-- Canonical starting schema. Idempotent — safe on a fresh DB or one that
+-- already has some/all of these objects (should no-op, not error).
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id                  INT PRIMARY KEY AUTO_INCREMENT,
+    title               VARCHAR(255) NOT NULL,
+    company             VARCHAR(255) NOT NULL,
+    company_logo_url    VARCHAR(512),
+    description         TEXT,
+    apply_url           VARCHAR(512) NOT NULL,
+    affiliate_apply_url VARCHAR(512),
+    source              ENUM('remotive','weworkremotely','jobicy','jobscollider',
+                             'manual','employer_submission') NOT NULL,
+    source_id           VARCHAR(255) NOT NULL,
+    role_type           VARCHAR(100) NOT NULL DEFAULT 'Uncategorised',
+    location_type       ENUM('africa_remote','africa_onsite','international_remote'),
+    location_detail     VARCHAR(255),
+    africa_friendly     TINYINT(1)  NOT NULL DEFAULT 0,
+    salary_min          INT,
+    salary_max          INT,
+    salary_currency     VARCHAR(10) DEFAULT 'USD',
+    salary_period       ENUM('monthly','annual'),
+    experience_level    ENUM('junior','mid','senior','lead','any'),
+    posted_at           DATETIME,
+    fetched_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    closes_at           DATETIME,
+    is_active           TINYINT(1)  NOT NULL DEFAULT 1,
+    is_featured         TINYINT(1)  NOT NULL DEFAULT 0,
+    featured_until      DATETIME,
+    is_approved         TINYINT(1)  NOT NULL DEFAULT 1,
+    is_notified         TINYINT(1)  NOT NULL DEFAULT 0,
+    tags                JSON,
+    created_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY unique_source_job (source, source_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS sync_log (
+    id            INT PRIMARY KEY AUTO_INCREMENT,
+    source        VARCHAR(50) NOT NULL,
+    ran_at        DATETIME DEFAULT CURRENT_TIMESTAMP,
+    jobs_fetched  INT DEFAULT 0,
+    jobs_inserted INT DEFAULT 0,
+    jobs_skipped  INT DEFAULT 0,
+    jobs_expired  INT DEFAULT 0,
+    jobs_purged   INT DEFAULT 0,
+    duration_sec  INT,
+    errors        TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS notifications_log (
+    id                INT PRIMARY KEY AUTO_INCREMENT,
+    channel           ENUM('telegram','discord','whatsapp','twitter','linkedin') NOT NULL,
+    notification_type ENUM('daily_digest','weekly_roundup','instant_alert') NOT NULL,
+    job_ids           JSON,
+    message_preview   TEXT,
+    sent_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
+    status            ENUM('sent','failed') NOT NULL,
+    error             TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version    VARCHAR(20) PRIMARY KEY,
+    filename   VARCHAR(255) NOT NULL,
+    applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Guarded column repairs for partially-created tables (safe to re-run) ───
+SET @schema = DATABASE();
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='company_logo_url'),
+    'ALTER TABLE jobs ADD COLUMN company_logo_url VARCHAR(512) AFTER company', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='affiliate_apply_url'),
+    'ALTER TABLE jobs ADD COLUMN affiliate_apply_url VARCHAR(512) AFTER apply_url', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='role_type'),
+    'ALTER TABLE jobs ADD COLUMN role_type VARCHAR(100) NOT NULL DEFAULT \'Uncategorised\' AFTER source_id', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='location_type'),
+    'ALTER TABLE jobs ADD COLUMN location_type ENUM(\'africa_remote\',\'africa_onsite\',\'international_remote\') AFTER role_type', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='location_detail'),
+    'ALTER TABLE jobs ADD COLUMN location_detail VARCHAR(255) AFTER location_type', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='africa_friendly'),
+    'ALTER TABLE jobs ADD COLUMN africa_friendly TINYINT(1) NOT NULL DEFAULT 0 AFTER location_detail', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='salary_min'),
+    'ALTER TABLE jobs ADD COLUMN salary_min INT AFTER africa_friendly', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='salary_max'),
+    'ALTER TABLE jobs ADD COLUMN salary_max INT AFTER salary_min', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='salary_currency'),
+    'ALTER TABLE jobs ADD COLUMN salary_currency VARCHAR(10) DEFAULT \'USD\' AFTER salary_max', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='salary_period'),
+    'ALTER TABLE jobs ADD COLUMN salary_period ENUM(\'monthly\',\'annual\') AFTER salary_currency', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='experience_level'),
+    'ALTER TABLE jobs ADD COLUMN experience_level ENUM(\'junior\',\'mid\',\'senior\',\'lead\',\'any\') AFTER salary_period', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='posted_at'),
+    'ALTER TABLE jobs ADD COLUMN posted_at DATETIME AFTER experience_level', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='fetched_at'),
+    'ALTER TABLE jobs ADD COLUMN fetched_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER posted_at', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='closes_at'),
+    'ALTER TABLE jobs ADD COLUMN closes_at DATETIME AFTER fetched_at', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='is_active'),
+    'ALTER TABLE jobs ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER closes_at', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='is_featured'),
+    'ALTER TABLE jobs ADD COLUMN is_featured TINYINT(1) NOT NULL DEFAULT 0 AFTER is_active', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='featured_until'),
+    'ALTER TABLE jobs ADD COLUMN featured_until DATETIME AFTER is_featured', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='is_approved'),
+    'ALTER TABLE jobs ADD COLUMN is_approved TINYINT(1) NOT NULL DEFAULT 1 AFTER featured_until', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='is_notified'),
+    'ALTER TABLE jobs ADD COLUMN is_notified TINYINT(1) NOT NULL DEFAULT 0 AFTER is_approved', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='tags'),
+    'ALTER TABLE jobs ADD COLUMN tags JSON AFTER is_notified', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='created_at'),
+    'ALTER TABLE jobs ADD COLUMN created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER tags', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='updated_at'),
+    'ALTER TABLE jobs ADD COLUMN updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='jobs_fetched'),
+    'ALTER TABLE sync_log ADD COLUMN jobs_fetched INT DEFAULT 0', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='jobs_inserted'),
+    'ALTER TABLE sync_log ADD COLUMN jobs_inserted INT DEFAULT 0', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='jobs_skipped'),
+    'ALTER TABLE sync_log ADD COLUMN jobs_skipped INT DEFAULT 0', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='jobs_expired'),
+    'ALTER TABLE sync_log ADD COLUMN jobs_expired INT DEFAULT 0', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='jobs_purged'),
+    'ALTER TABLE sync_log ADD COLUMN jobs_purged INT DEFAULT 0', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='duration_sec'),
+    'ALTER TABLE sync_log ADD COLUMN duration_sec INT', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='errors'),
+    'ALTER TABLE sync_log ADD COLUMN errors TEXT', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='channel'),
+    'ALTER TABLE notifications_log ADD COLUMN channel ENUM(\'telegram\',\'discord\',\'whatsapp\',\'twitter\',\'linkedin\') NOT NULL', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='notification_type'),
+    'ALTER TABLE notifications_log ADD COLUMN notification_type ENUM(\'daily_digest\',\'weekly_roundup\',\'instant_alert\') NOT NULL', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='job_ids'),
+    'ALTER TABLE notifications_log ADD COLUMN job_ids JSON', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='message_preview'),
+    'ALTER TABLE notifications_log ADD COLUMN message_preview TEXT', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='sent_at'),
+    'ALTER TABLE notifications_log ADD COLUMN sent_at DATETIME DEFAULT CURRENT_TIMESTAMP', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='status'),
+    'ALTER TABLE notifications_log ADD COLUMN status ENUM(\'sent\',\'failed\') NOT NULL', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='error'),
+    'ALTER TABLE notifications_log ADD COLUMN error TEXT', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='schema_migrations' AND column_name='filename'),
+    'ALTER TABLE schema_migrations ADD COLUMN filename VARCHAR(255) NOT NULL', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='schema_migrations' AND column_name='applied_at'),
+    'ALTER TABLE schema_migrations ADD COLUMN applied_at DATETIME DEFAULT CURRENT_TIMESTAMP', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ── Guarded index adds (information_schema-checked, safe to re-run) ──────────
+SET @schema = DATABASE();
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_is_active'),
+    'CREATE INDEX idx_is_active ON jobs (is_active)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_closes_at'),
+    'CREATE INDEX idx_closes_at ON jobs (closes_at)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_location_type'),
+    'CREATE INDEX idx_location_type ON jobs (location_type)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_role_type'),
+    'CREATE INDEX idx_role_type ON jobs (role_type)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_is_notified'),
+    'CREATE INDEX idx_is_notified ON jobs (is_notified)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_fetched_at'),
+    'CREATE INDEX idx_fetched_at ON jobs (fetched_at)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_posted_at'),
+    'CREATE INDEX idx_posted_at ON jobs (posted_at)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/backend/migrations/002_add_last_synced_at.sql
+++ b/backend/migrations/002_add_last_synced_at.sql
@@ -39,9 +39,12 @@ SET @sql = (SELECT IF(
     'SELECT 1'));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
+-- Also backfill status for rows where errors exist — but note: future INSERTs
+-- in sync_*.php now set status explicitly ('success'/'partial'/'failed'), so
+-- the 'success' default only applies to rows created by older code.
 SET @sql = (SELECT IF(
     @status_column_added = '1',
-    'UPDATE sync_log SET status = CASE WHEN COALESCE(TRIM(errors), \"\") = \"\" THEN \'success\' ELSE \'failed\' END',
+    "UPDATE sync_log SET status = CASE WHEN COALESCE(TRIM(errors), '') = '' THEN 'success' ELSE 'failed' END",
     'SELECT 1'));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 

--- a/backend/migrations/002_add_last_synced_at.sql
+++ b/backend/migrations/002_add_last_synced_at.sql
@@ -44,7 +44,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 -- the 'success' default only applies to rows created by older code.
 SET @sql = (SELECT IF(
     @status_column_added = '1',
-    "UPDATE sync_log SET status = CASE WHEN COALESCE(TRIM(errors), '') = '' THEN 'success' ELSE 'failed' END",
+    'UPDATE sync_log SET status = CASE WHEN COALESCE(TRIM(errors), \'\') = \'\' THEN \'success\' ELSE \'failed\' END',
     'SELECT 1'));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 

--- a/backend/migrations/002_add_last_synced_at.sql
+++ b/backend/migrations/002_add_last_synced_at.sql
@@ -1,0 +1,58 @@
+-- 002_add_last_synced_at.sql
+-- Adds last_synced_at (for stale-listing expiry — distinct from fetched_at,
+-- which only records first insert). Backfills role_type default. Adds
+-- jobs_updated/status to sync_log for richer per-run reporting.
+-- Every ALTER is information_schema-guarded — safe to re-run.
+
+SET @schema = DATABASE();
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='last_synced_at'),
+    'ALTER TABLE jobs ADD COLUMN last_synced_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER fetched_at',
+    'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='jobs' AND column_name='role_type'
+                  AND column_default = 'Uncategorised'),
+    'ALTER TABLE jobs MODIFY COLUMN role_type VARCHAR(100) NOT NULL DEFAULT \'Uncategorised\'',
+    'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='jobs_updated'),
+    'ALTER TABLE sync_log ADD COLUMN jobs_updated INT DEFAULT 0 AFTER jobs_inserted',
+    'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @status_column_added = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
+                WHERE table_schema=@schema AND table_name='sync_log' AND column_name='status'),
+    '1', '0'));
+
+SET @sql = (SELECT IF(
+    @status_column_added = '1',
+    'ALTER TABLE sync_log ADD COLUMN status ENUM(\'success\',\'partial\',\'failed\') NOT NULL DEFAULT \'success\' AFTER duration_sec',
+    'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    @status_column_added = '1',
+    'UPDATE sync_log SET status = CASE WHEN COALESCE(TRIM(errors), \"\") = \"\" THEN \'success\' ELSE \'failed\' END',
+    'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_last_synced_at'),
+    'CREATE INDEX idx_last_synced_at ON jobs (last_synced_at)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = (SELECT IF(
+    NOT EXISTS (SELECT 1 FROM information_schema.STATISTICS
+                WHERE table_schema=@schema AND table_name='jobs' AND index_name='idx_active_approved_posted'),
+    'CREATE INDEX idx_active_approved_posted ON jobs (is_active, is_approved, posted_at)', 'SELECT 1'));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/backend/migrations/003_initial_schema.sql
+++ b/backend/migrations/003_initial_schema.sql
@@ -1,4 +1,4 @@
--- 001_initial_schema.sql
+-- 003_initial_schema.sql
 -- Canonical starting schema. Idempotent — safe on a fresh DB or one that
 -- already has some/all of these objects (should no-op, not error).
 
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS sync_log (
 
 CREATE TABLE IF NOT EXISTS notifications_log (
     id                INT PRIMARY KEY AUTO_INCREMENT,
-    channel           ENUM('telegram','discord','whatsapp','twitter','linkedin') NOT NULL,
+    channel           VARCHAR(50) NOT NULL,
     notification_type ENUM('daily_digest','weekly_roundup','instant_alert') NOT NULL,
     job_ids           JSON,
     message_preview   TEXT,
@@ -65,6 +65,18 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
     version    VARCHAR(20) PRIMARY KEY,
     filename   VARCHAR(255) NOT NULL,
     applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS job_clicks (
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    job_id      INT          NOT NULL,
+    click_type  ENUM('apply','affiliate_apply') NOT NULL DEFAULT 'apply',
+    clicked_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_job_id  (job_id),
+    INDEX idx_clicked (clicked_at),
+    FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ── Guarded column repairs for partially-created tables (safe to re-run) ───
@@ -247,7 +259,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = (SELECT IF(
     NOT EXISTS (SELECT 1 FROM information_schema.COLUMNS
                 WHERE table_schema=@schema AND table_name='notifications_log' AND column_name='channel'),
-    'ALTER TABLE notifications_log ADD COLUMN channel ENUM(\'telegram\',\'discord\',\'whatsapp\',\'twitter\',\'linkedin\') NOT NULL', 'SELECT 1'));
+    'ALTER TABLE notifications_log ADD COLUMN channel VARCHAR(50) NOT NULL', 'SELECT 1'));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = (SELECT IF(

--- a/backend/phpunit.xml.dist
+++ b/backend/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true">
+    <testsuites>
+        <testsuite name="Backend">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/backend/src/Contracts/JobFetcherInterface.php
+++ b/backend/src/Contracts/JobFetcherInterface.php
@@ -9,7 +9,7 @@ namespace App\Contracts;
  * return raw, unvalidated response data as an array of per-job records.
  *
  * No parsing into the internal schema here (that's JobNormalizerInterface's
- * job) and no DB access here (that's JobRepositoryInterface's job). This
+ * job) and no DB access here (that's the repository/persistence layer's job). This
  * separation is what lets "Remotive is down" degrade independently of
  * "We Work Remotely succeeded" — each fetcher fails or succeeds on its own.
  */

--- a/backend/src/Contracts/JobFetcherInterface.php
+++ b/backend/src/Contracts/JobFetcherInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+/**
+ * A fetcher's only responsibility: talk HTTP to one external job source and
+ * return raw, unvalidated response data as an array of per-job records.
+ *
+ * No parsing into the internal schema here (that's JobNormalizerInterface's
+ * job) and no DB access here (that's JobRepositoryInterface's job). This
+ * separation is what lets "Remotive is down" degrade independently of
+ * "We Work Remotely succeeded" — each fetcher fails or succeeds on its own.
+ */
+interface JobFetcherInterface
+{
+    /**
+     * @return array<int, array<string, mixed>> Raw per-job records, exactly
+     *         as returned by the source (before any normalization/validation)
+     *
+     * @throws \App\Exception\SourceUnavailableException on network failure,
+     *         timeout, rate-limit, or non-2xx response after retries are
+     *         exhausted. Never returns a partial/corrupt result silently.
+     */
+    public function fetch(): array;
+
+    /** Source slug matching the jobs.source ENUM value, e.g. 'remotive' */
+    public function sourceName(): string;
+}

--- a/backend/src/Contracts/JobNormalizerInterface.php
+++ b/backend/src/Contracts/JobNormalizerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Model\NormalizedJob;
+
+/**
+ * Maps one source's raw record shape into the internal NormalizedJob model.
+ *
+ * Implementations MUST validate that required fields are present and of the
+ * expected type before trusting them — never assume an external API's shape
+ * is stable. Implementations MUST call mapRoleType() from helpers.php for
+ * role classification — never reimplement keyword matching here or in any
+ * sync file. All string output must be sanitized (see sanitizeString() /
+ * cleanDescription() in helpers.php) since external API data is untrusted
+ * input that will later be rendered to end users.
+ */
+interface JobNormalizerInterface
+{
+    /**
+     * @param array<string, mixed> $raw One raw record from the fetcher
+     *
+     * @throws \App\Exception\InvalidJobRecordException if required fields
+     *         are missing or malformed. The sync runner catches this per
+     *         record so one bad listing never aborts the whole batch.
+     */
+    public function normalize(array $raw): NormalizedJob;
+}

--- a/backend/src/Exception/InvalidJobRecordException.php
+++ b/backend/src/Exception/InvalidJobRecordException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown by a normalizer when a single raw record is missing required
+ * fields or has a shape that can't be safely normalized.
+ *
+ * The sync runner catches this per-record — one malformed listing from a
+ * source is logged and skipped, it never aborts the rest of that source's
+ * batch.
+ */
+final class InvalidJobRecordException extends RuntimeException
+{
+}

--- a/backend/src/Exception/MigrationException.php
+++ b/backend/src/Exception/MigrationException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when a migration file fails validation — invalid filename format,
+ * duplicate version, unreadable file, or execution failure.
+ *
+ * The migration runner stops at the first failure to avoid leaving the
+ * database in a partially-migrated state.
+ */
+final class MigrationException extends RuntimeException
+{
+}

--- a/backend/src/Exception/SourceUnavailableException.php
+++ b/backend/src/Exception/SourceUnavailableException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown by a fetcher when its source could not be reached after retries
+ * are exhausted (timeout, connection failure, rate-limited, non-2xx status).
+ *
+ * The sync runner catches this per-source so one source being down never
+ * prevents other sources from syncing successfully in the same run.
+ */
+final class SourceUnavailableException extends RuntimeException
+{
+}

--- a/backend/src/Fetcher/RemotiveFetcher.php
+++ b/backend/src/Fetcher/RemotiveFetcher.php
@@ -24,7 +24,6 @@ final class RemotiveFetcher implements JobFetcherInterface
     private const BASE_URL = 'https://remotive.com/api/remote-jobs';
     private const USER_AGENT = 'NairobiDevOps-JobsBot/1.0 (nairobidevops.org)';
     public const MAX_ATTEMPTS = 3;
-    private const INITIAL_BACKOFF_MS = 500;
 
     /** @var string[] Remotive category slugs to fetch, per the PRD's Tier 1 source spec */
     public const CATEGORIES = ['devops-sysadmin', 'software-dev', 'cloud'];
@@ -33,6 +32,8 @@ final class RemotiveFetcher implements JobFetcherInterface
         private readonly HttpClientInterface $httpClient,
         private readonly int $timeoutSeconds = 20,
         private readonly int $limitPerCategory = 100,
+        private readonly int $initialBackoffMs = 500,
+        private readonly int $rateLimitBackoffMs = 30_000,
     ) {
     }
 
@@ -53,7 +54,11 @@ final class RemotiveFetcher implements JobFetcherInterface
         $allJobs = [];
         $categoryErrors = [];
 
-        foreach (self::CATEGORIES as $category) {
+        foreach (self::CATEGORIES as $i => $category) {
+            if ($i > 0) {
+                usleep(1_000_000); // 1s pacing between categories
+            }
+
             try {
                 $allJobs = [...$allJobs, ...$this->fetchCategory($category)];
             } catch (SourceUnavailableException $e) {
@@ -93,7 +98,10 @@ final class RemotiveFetcher implements JobFetcherInterface
                 $lastError = $e;
 
                 if ($attempt < self::MAX_ATTEMPTS) {
-                    $backoffMs = self::INITIAL_BACKOFF_MS * (2 ** ($attempt - 1));
+                    $isRateLimit = str_contains($e->getMessage(), 'Rate limited');
+                    $backoffMs = $isRateLimit
+                        ? $this->rateLimitBackoffMs
+                        : $this->initialBackoffMs * (2 ** ($attempt - 1));
                     usleep($backoffMs * 1000);
                 }
             }

--- a/backend/src/Fetcher/RemotiveFetcher.php
+++ b/backend/src/Fetcher/RemotiveFetcher.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Fetcher;
+
+use App\Contracts\JobFetcherInterface;
+use App\Exception\SourceUnavailableException;
+use App\Http\HttpClientInterface;
+
+/**
+ * Fetches raw job listings from the Remotive API.
+ *
+ * HTTP concerns only — no parsing into the internal schema (RemotiveNormalizer's
+ * job) and no DB access (JobRepository's job). Retries transient failures with
+ * exponential backoff before giving up and throwing SourceUnavailableException.
+ *
+ * Rate limiting: Remotive allows max 4 fetches/day. This class makes one HTTP
+ * call per category per fetch() invocation — the cron schedule (every 6 hours)
+ * enforces the 4x/day cap, not this class.
+ */
+final class RemotiveFetcher implements JobFetcherInterface
+{
+    private const BASE_URL = 'https://remotive.com/api/remote-jobs';
+    private const USER_AGENT = 'NairobiDevOps-JobsBot/1.0 (nairobidevops.org)';
+    public const MAX_ATTEMPTS = 3;
+    private const INITIAL_BACKOFF_MS = 500;
+
+    /** @var string[] Remotive category slugs to fetch, per the PRD's Tier 1 source spec */
+    public const CATEGORIES = ['devops-sysadmin', 'software-dev', 'cloud'];
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly int $timeoutSeconds = 20,
+        private readonly int $limitPerCategory = 100,
+    ) {
+    }
+
+    public function sourceName(): string
+    {
+        return 'remotive';
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     *
+     * @throws SourceUnavailableException if any category fails after retries.
+     *         Partial success is still surfaced to the caller so the fetcher
+     *         does not silently return a partial result.
+     */
+    public function fetch(): array
+    {
+        $allJobs = [];
+        $categoryErrors = [];
+
+        foreach (self::CATEGORIES as $category) {
+            try {
+                $allJobs = [...$allJobs, ...$this->fetchCategory($category)];
+            } catch (SourceUnavailableException $e) {
+                $categoryErrors[] = "{$category}: {$e->getMessage()}";
+            }
+        }
+
+        if (!empty($categoryErrors)) {
+            $message = empty($allJobs)
+                ? 'Remotive fetch failed for all categories: ' . implode('; ', $categoryErrors)
+                : 'Remotive fetch had partial failures: ' . implode('; ', $categoryErrors);
+
+            throw new SourceUnavailableException($message);
+        }
+
+        return $allJobs;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     *
+     * @throws SourceUnavailableException after MAX_ATTEMPTS exhausted
+     */
+    private function fetchCategory(string $category): array
+    {
+        $url = self::BASE_URL . '?' . http_build_query([
+            'category' => $category,
+            'limit'    => $this->limitPerCategory,
+        ]);
+
+        $lastError = null;
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            try {
+                return $this->executeRequest($url);
+            } catch (SourceUnavailableException $e) {
+                $lastError = $e;
+
+                if ($attempt < self::MAX_ATTEMPTS) {
+                    $backoffMs = self::INITIAL_BACKOFF_MS * (2 ** ($attempt - 1));
+                    usleep($backoffMs * 1000);
+                }
+            }
+        }
+
+        throw new SourceUnavailableException(
+            "Remotive category '{$category}' failed after " . self::MAX_ATTEMPTS . ' attempts: '
+                . ($lastError?->getMessage() ?? 'unknown error')
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     *
+     * @throws SourceUnavailableException on transport failure, non-200 response,
+     *         invalid JSON, or a response missing the expected "jobs" key
+     */
+    private function executeRequest(string $url): array
+    {
+        $result = $this->httpClient->get(
+            $url,
+            ['User-Agent' => self::USER_AGENT, 'Accept' => 'application/json'],
+            $this->timeoutSeconds
+        );
+
+        if ($result['error'] !== '') {
+            throw new SourceUnavailableException("cURL error: {$result['error']}");
+        }
+
+        if ($result['status'] === 429) {
+            throw new SourceUnavailableException('Rate limited (HTTP 429)');
+        }
+
+        if ($result['status'] !== 200) {
+            throw new SourceUnavailableException("HTTP {$result['status']}");
+        }
+
+        if ($result['body'] === '') {
+            throw new SourceUnavailableException('Empty response body');
+        }
+
+        $decoded = json_decode($result['body'], true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new SourceUnavailableException('Invalid JSON: ' . json_last_error_msg());
+        }
+
+        if (!\is_array($decoded) || !\array_key_exists('jobs', $decoded) || !\is_array($decoded['jobs'])) {
+            throw new SourceUnavailableException('Response missing expected "jobs" array');
+        }
+
+        return $decoded['jobs'];
+    }
+}

--- a/backend/src/Http/CurlHttpClient.php
+++ b/backend/src/Http/CurlHttpClient.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http;
+
+use App\Exception\SourceUnavailableException;
+
+/**
+ * Production HttpClientInterface implementation using PHP's cURL extension.
+ */
+final class CurlHttpClient implements HttpClientInterface
+{
+    public function get(string $url, array $headers, int $timeoutSeconds): array
+    {
+        $headerLines = [];
+        foreach ($headers as $name => $value) {
+            $headerLines[] = "{$name}: {$value}";
+        }
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            throw new SourceUnavailableException("cURL failed to initialize for {$url}");
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => $timeoutSeconds,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS      => 3,
+            CURLOPT_HTTPHEADER     => $headerLines,
+        ]);
+
+        $response = curl_exec($ch);
+        $status   = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error    = curl_error($ch);
+        curl_close($ch);
+
+        return [
+            'status' => (int) $status,
+            'body'   => $response === false ? '' : (string) $response,
+            'error'  => $error,
+        ];
+    }
+}

--- a/backend/src/Http/CurlHttpClient.php
+++ b/backend/src/Http/CurlHttpClient.php
@@ -23,13 +23,17 @@ final class CurlHttpClient implements HttpClientInterface
             throw new SourceUnavailableException("cURL failed to initialize for {$url}");
         }
 
-        curl_setopt_array($ch, [
+        $ok = curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT        => $timeoutSeconds,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS      => 3,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTPS,
             CURLOPT_HTTPHEADER     => $headerLines,
         ]);
+        if ($ok === false) {
+            throw new SourceUnavailableException("cURL failed to set options for {$url}");
+        }
 
         $response = curl_exec($ch);
         $status   = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/backend/src/Http/HttpClientInterface.php
+++ b/backend/src/Http/HttpClientInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http;
+
+/**
+ * Minimal HTTP transport abstraction so fetchers are testable without
+ * mocking global curl_*() functions or hitting the real network.
+ */
+interface HttpClientInterface
+{
+    /**
+     * @param array<string, string> $headers
+     * @return array{status: int, body: string, error: string}
+     */
+    public function get(string $url, array $headers, int $timeoutSeconds): array;
+}

--- a/backend/src/Migration/MigrationRunner.php
+++ b/backend/src/Migration/MigrationRunner.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migration;
+
+use App\Exception\MigrationException;
+use PDO;
+use PDOException;
+
+/**
+ * Applies versioned SQL migration files (backend/migrations/NNN_*.sql) against
+ * a PDO connection, tracking what's already applied in schema_migrations so
+ * re-running never re-applies a file that already succeeded.
+ *
+ * This class only orchestrates — it never opens its own DB connection and
+ * never touches config.php. The caller (cron/migrate.php) supplies a PDO
+ * from db.php's getDB().
+ */
+final class MigrationRunner
+{
+    public function __construct(
+        private readonly PDO $db,
+        private readonly string $migrationsPath,
+    ) {
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+
+    public function ensureMigrationsTableExists(): void
+    {
+        $this->db->exec('CREATE TABLE IF NOT EXISTS schema_migrations (
+            version    VARCHAR(20) PRIMARY KEY,
+            filename   VARCHAR(255) NOT NULL,
+            applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    /**
+     * @return string[] Already-applied version strings, e.g. ['001', '002']
+     */
+    public function appliedVersions(): array
+    {
+        $stmt = $this->db->query('SELECT version FROM schema_migrations ORDER BY version');
+
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Scans the migrations directory for NNN_*.sql files.
+     *
+     * @return array<string, string> version => absolute filepath, sorted ascending by filename
+     */
+    public function discoverMigrationFiles(): array
+    {
+        $files = glob(rtrim($this->migrationsPath, '/\\') . '/*.sql') ?: [];
+        sort($files);
+
+        $out = [];
+        foreach ($files as $file) {
+            $filename = basename($file);
+            if (!preg_match('/^(\d{3})_.+\.sql$/', $filename, $matches)) {
+                throw new MigrationException("Invalid migration filename: {$filename}");
+            }
+
+            $version = $matches[1];
+            if (\array_key_exists($version, $out)) {
+                throw new MigrationException("Duplicate migration version {$version} in {$filename}");
+            }
+
+            $out[$version] = $file;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, string> version => filepath, only those not yet applied
+     */
+    public function pendingMigrations(): array
+    {
+        $applied = $this->appliedVersions();
+
+        return array_diff_key($this->discoverMigrationFiles(), array_flip($applied));
+    }
+
+    /**
+     * Applies one migration file and records it in schema_migrations.
+     * On failure: rolls back and never records the version, so a retry
+     * after fixing the file will pick it up again as pending.
+     *
+     * @throws MigrationException on any failure reading or executing the file
+     */
+    public function apply(string $version, string $filepath): void
+    {
+        $sql = file_get_contents($filepath);
+        if ($sql === false) {
+            throw new MigrationException("Could not read migration file: {$filepath}");
+        }
+
+        $this->db->beginTransaction();
+
+        try {
+            // exec() (not query()) — migration files contain multi-statement
+            // SQL (PREPARE/EXECUTE blocks), which query() cannot run.
+            $result = $this->db->exec($sql);
+            if ($result === false) {
+                throw new MigrationException("Migration {$version} failed: exec() returned false");
+            }
+
+            $stmt = $this->db->prepare(
+                'INSERT INTO schema_migrations (version, filename) VALUES (?, ?)'
+            );
+            if ($stmt === false) {
+                throw new MigrationException("Migration {$version} failed: could not prepare migration record insert");
+            }
+
+            $stmt->execute([$version, basename($filepath)]);
+
+            $this->db->commit();
+        } catch (PDOException $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+
+            throw new MigrationException(
+                "Migration {$version} failed: {$e->getMessage()}",
+                0,
+                $e
+            );
+        } catch (MigrationException $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Runs all pending migrations in ascending version order.
+     * Stops at the first failure — later migrations are never attempted
+     * against a DB left in a possibly-inconsistent state.
+     */
+    public function runAll(): void
+    {
+        $this->ensureMigrationsTableExists();
+
+        foreach ($this->pendingMigrations() as $version => $filepath) {
+            $this->apply($version, $filepath);
+        }
+    }
+}

--- a/backend/src/Migration/MigrationRunner.php
+++ b/backend/src/Migration/MigrationRunner.php
@@ -42,7 +42,7 @@ final class MigrationRunner
     {
         $stmt = $this->db->query('SELECT version FROM schema_migrations ORDER BY version');
 
-        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+        return $stmt->fetchAll(PDO::FETCH_COLUMN);
     }
 
     /**
@@ -99,22 +99,15 @@ final class MigrationRunner
 
         $this->db->beginTransaction();
 
+        // NOTE: MySQL DDL (ALTER TABLE, CREATE TABLE) auto-commits and cannot
+        // be rolled back. The transaction here primarily protects the
+        // schema_migrations INSERT — migration SQL files use idempotent guards
+        // (IF NOT EXISTS, information_schema checks) to handle partial DDL.
         try {
-            // exec() (not query()) — migration files contain multi-statement
-            // SQL (PREPARE/EXECUTE blocks), which query() cannot run.
-            $result = $this->db->exec($sql);
-            if ($result === false) {
-                throw new MigrationException("Migration {$version} failed: exec() returned false");
-            }
-
-            $stmt = $this->db->prepare(
+            $this->db->exec($sql);
+            $this->db->prepare(
                 'INSERT INTO schema_migrations (version, filename) VALUES (?, ?)'
-            );
-            if ($stmt === false) {
-                throw new MigrationException("Migration {$version} failed: could not prepare migration record insert");
-            }
-
-            $stmt->execute([$version, basename($filepath)]);
+            )->execute([$version, basename($filepath)]);
 
             $this->db->commit();
         } catch (PDOException $e) {

--- a/backend/src/Model/NormalizedJob.php
+++ b/backend/src/Model/NormalizedJob.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use DateTimeImmutable;
+
+/**
+ * The single internal job shape every source's normalizer must produce.
+ * A plain, immutable value object — no DB or HTTP concerns, no behavior
+ * beyond holding validated, sanitized data.
+ *
+ * Field values here are always safe to store and safe to render — sanitization
+ * happens in the normalizer before this object is constructed, not after.
+ */
+final class NormalizedJob
+{
+    /**
+     * @param string[] $tags
+     */
+    public function __construct(
+        public readonly string $title,
+        public readonly string $company,
+        public readonly ?string $companyLogoUrl,
+        public readonly string $description,        // pre-sanitized plain text, no HTML
+        public readonly string $applyUrl,
+        public readonly string $source,               // matches jobs.source ENUM
+        public readonly string $sourceId,              // dedup anchor within a source
+        public readonly string $roleType,              // ALWAYS via mapRoleType() — see helpers.php
+        public readonly string $locationType,          // default 'international_remote' unless source states otherwise
+        public readonly ?string $locationDetail,
+        public readonly bool $africaFriendly,           // ALWAYS false unless source explicitly confirms it
+        public readonly ?int $salaryMin,
+        public readonly ?int $salaryMax,
+        public readonly string $salaryCurrency,
+        public readonly ?string $salaryPeriod,
+        public readonly ?DateTimeImmutable $postedAt,
+        public readonly array $tags,
+    ) {
+    }
+}

--- a/backend/tests/Fetcher/RemotiveFetcherTest.php
+++ b/backend/tests/Fetcher/RemotiveFetcherTest.php
@@ -30,7 +30,7 @@ final class RemotiveFetcherTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_partial_results_when_one_category_fails(): void
+    public function it_throws_on_partial_failure_when_one_category_fails(): void
     {
         $client = $this->createMock(HttpClientInterface::class);
 
@@ -76,7 +76,7 @@ final class RemotiveFetcherTest extends TestCase
             ->method('get')
             ->willReturn(['status' => 429, 'body' => '', 'error' => '']);
 
-        $fetcher = new RemotiveFetcher($client);
+        $fetcher = new RemotiveFetcher($client, initialBackoffMs: 1, rateLimitBackoffMs: 1);
 
         $this->expectException(SourceUnavailableException::class);
         $fetcher->fetch();

--- a/backend/tests/Fetcher/RemotiveFetcherTest.php
+++ b/backend/tests/Fetcher/RemotiveFetcherTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fetcher;
+
+use App\Exception\SourceUnavailableException;
+use App\Fetcher\RemotiveFetcher;
+use App\Http\HttpClientInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RemotiveFetcherTest extends TestCase
+{
+    #[Test]
+    public function it_returns_jobs_when_all_categories_succeed(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn([
+            'status' => 200,
+            'body'   => json_encode(['jobs' => [['id' => 1, 'title' => 'DevOps Engineer']]]),
+            'error'  => '',
+        ]);
+
+        $fetcher = new RemotiveFetcher($client);
+        $jobs = $fetcher->fetch();
+
+        self::assertCount(\count(RemotiveFetcher::CATEGORIES), $jobs);
+        self::assertSame('DevOps Engineer', $jobs[0]['title']);
+    }
+
+    #[Test]
+    public function it_returns_partial_results_when_one_category_fails(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+
+        $client->method('get')->willReturnCallback(static function (string $url): array {
+            if (str_contains($url, 'category=devops-sysadmin')) {
+                return ['status' => 500, 'body' => '', 'error' => ''];
+            }
+
+            return [
+                'status' => 200,
+                'body'   => json_encode(['jobs' => [['id' => 2, 'title' => 'SRE']]]),
+                'error'  => '',
+            ];
+        });
+
+        $fetcher = new RemotiveFetcher($client);
+
+        $this->expectException(SourceUnavailableException::class);
+        $this->expectExceptionMessageMatches('/partial/i');
+
+        $fetcher->fetch();
+    }
+
+    #[Test]
+    public function it_throws_when_every_category_fails_after_retries(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn(['status' => 500, 'body' => '', 'error' => '']);
+
+        $fetcher = new RemotiveFetcher($client);
+
+        $this->expectException(SourceUnavailableException::class);
+        $this->expectExceptionMessageMatches('/failed for all categories/');
+
+        $fetcher->fetch();
+    }
+
+    #[Test]
+    public function it_retries_on_rate_limit_before_giving_up(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->expects(self::exactly(\count(RemotiveFetcher::CATEGORIES) * RemotiveFetcher::MAX_ATTEMPTS))
+            ->method('get')
+            ->willReturn(['status' => 429, 'body' => '', 'error' => '']);
+
+        $fetcher = new RemotiveFetcher($client);
+
+        $this->expectException(SourceUnavailableException::class);
+        $fetcher->fetch();
+    }
+
+    #[Test]
+    public function it_throws_on_malformed_json(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn(['status' => 200, 'body' => '{not valid json', 'error' => '']);
+
+        $fetcher = new RemotiveFetcher($client);
+
+        $this->expectException(SourceUnavailableException::class);
+        $fetcher->fetch();
+    }
+
+    #[Test]
+    public function it_throws_when_response_is_missing_jobs_key(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn([
+            'status' => 200,
+            'body'   => json_encode(['unexpected' => 'shape']),
+            'error'  => '',
+        ]);
+
+        $fetcher = new RemotiveFetcher($client);
+
+        $this->expectException(SourceUnavailableException::class);
+        $fetcher->fetch();
+    }
+
+    #[Test]
+    public function it_throws_when_jobs_key_is_not_an_array(): void
+    {
+        // Guards against a source returning {"jobs": "unexpected string"} —
+        // json_decode succeeds, the key exists, but the shape is still wrong.
+        // This is the "validate response shape, don't assume fields always
+        // exist" requirement from the PRD, not just "does the key exist".
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn([
+            'status' => 200,
+            'body'   => json_encode(['jobs' => 'not-an-array']),
+            'error'  => '',
+        ]);
+
+        $fetcher = new RemotiveFetcher($client);
+
+        $this->expectException(SourceUnavailableException::class);
+        $fetcher->fetch();
+    }
+
+    #[Test]
+    public function it_passes_through_raw_job_entries_without_per_field_validation(): void
+    {
+        // The fetcher's contract stops at "is this a well-formed API response
+        // with a jobs array?" — it does NOT inspect individual job fields.
+        // Dropping a record because it's missing a title is normalizer work
+        // (per the project's fetcher/normalizer/repository separation), so a
+        // malformed-but-structurally-valid entry is expected to pass through
+        // untouched here and be caught downstream instead.
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn([
+            'status' => 200,
+            'body'   => json_encode([
+                'jobs' => [
+                    ['id' => 1, 'title' => 'DevOps Engineer'],
+                    ['id' => 2], // missing title — validation is the normalizer's job, not the fetcher's
+                ],
+            ]),
+            'error'  => '',
+        ]);
+
+        $fetcher = new RemotiveFetcher($client);
+        $jobs = $fetcher->fetch();
+
+        // 3 categories × 2 raw entries each = 6; nothing is filtered at this layer
+        self::assertCount(6, $jobs);
+        self::assertArrayNotHasKey('title', $jobs[1]);
+    }
+
+    #[Test]
+    public function it_returns_an_empty_array_when_a_category_has_zero_open_jobs(): void
+    {
+        // A valid, well-formed response with no listings is not an error
+        // condition — it must not throw SourceUnavailableException.
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('get')->willReturn([
+            'status' => 200,
+            'body'   => json_encode(['jobs' => []]),
+            'error'  => '',
+        ]);
+
+        $fetcher = new RemotiveFetcher($client);
+        $jobs = $fetcher->fetch();
+
+        self::assertSame([], $jobs);
+    }
+
+    #[Test]
+    public function source_name_is_remotive(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $fetcher = new RemotiveFetcher($client);
+
+        self::assertSame('remotive', $fetcher->sourceName());
+    }
+}

--- a/backend/tests/HelpersTest.php
+++ b/backend/tests/HelpersTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../helpers.php';
@@ -40,9 +41,7 @@ class HelpersTest extends TestCase
     // isNonTechRole() — the hard block list checked FIRST in mapRoleType()
     // ════════════════════════════════════════════════════════════════════
 
-    /**
-     * @dataProvider nonTechTitleProvider
-     */
+    #[DataProvider('nonTechTitleProvider')]
     public function testIsNonTechRoleBlocksNonDevOpsDisciplines(string $title): void
     {
         $this->assertTrue(

--- a/backend/tests/Migration/MigrationRunnerTest.php
+++ b/backend/tests/Migration/MigrationRunnerTest.php
@@ -67,13 +67,16 @@ final class MigrationRunnerTest extends TestCase
         self::assertFalse($this->db->query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'partial_test'")->fetchColumn());
     }
 
-    public function testConstructorForcesExceptionModeForSqlFailures(): void
+    public function testApplyThrowsOnInvalidSql(): void
     {
         $db = new PDO('sqlite::memory:');
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $path = $this->fixturesPath . '/001_bad.sql';
         file_put_contents($path, 'THIS IS NOT VALID SQL;');
 
         $runner = new MigrationRunner($db, $this->fixturesPath);
+
+        self::assertSame(PDO::ERRMODE_EXCEPTION, $db->getAttribute(PDO::ATTR_ERRMODE));
 
         $this->expectException(RuntimeException::class);
         $runner->apply('001', $path);

--- a/backend/tests/Migration/MigrationRunnerTest.php
+++ b/backend/tests/Migration/MigrationRunnerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Migration;
+
+use App\Migration\MigrationRunner;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class MigrationRunnerTest extends TestCase
+{
+    private PDO $db;
+    private string $fixturesPath;
+
+    protected function setUp(): void
+    {
+        // SQLite in-memory — no MySQL connection needed for this test at all.
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->fixturesPath = sys_get_temp_dir() . '/migrations_test_' . uniqid();
+        mkdir($this->fixturesPath);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->fixturesPath . '/*.sql') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->fixturesPath);
+    }
+
+    public function testPendingMigrationsExcludesAlreadyApplied(): void
+    {
+        file_put_contents($this->fixturesPath . '/001_a.sql', 'CREATE TABLE a (id INTEGER);');
+        file_put_contents($this->fixturesPath . '/002_b.sql', 'CREATE TABLE b (id INTEGER);');
+
+        $runner = new MigrationRunner($this->db, $this->fixturesPath);
+        $runner->ensureMigrationsTableExists();
+        $runner->apply('001', $this->fixturesPath . '/001_a.sql');
+
+        $pending = $runner->pendingMigrations();
+
+        self::assertArrayNotHasKey('001', $pending);
+        self::assertArrayHasKey('002', $pending);
+    }
+
+    public function testFailedMigrationIsNotRecordedAndRollsBack(): void
+    {
+        $path = $this->fixturesPath . '/001_bad.sql';
+        file_put_contents($path, "CREATE TABLE partial_test (id INTEGER);\nTHIS IS NOT VALID SQL;");
+
+        $runner = new MigrationRunner($this->db, $this->fixturesPath);
+        $runner->ensureMigrationsTableExists();
+
+        try {
+            $runner->apply('001', $path);
+            self::fail('Expected RuntimeException was not thrown');
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertSame([], $runner->appliedVersions());
+        self::assertSame(['001' => $path], $runner->pendingMigrations());
+        self::assertFalse($this->db->query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'partial_test'")->fetchColumn());
+    }
+
+    public function testConstructorForcesExceptionModeForSqlFailures(): void
+    {
+        $db = new PDO('sqlite::memory:');
+        $path = $this->fixturesPath . '/001_bad.sql';
+        file_put_contents($path, 'THIS IS NOT VALID SQL;');
+
+        $runner = new MigrationRunner($db, $this->fixturesPath);
+
+        $this->expectException(RuntimeException::class);
+        $runner->apply('001', $path);
+    }
+
+    public function testMigrationsDiscoveredInAscendingFilenameOrder(): void
+    {
+        file_put_contents($this->fixturesPath . '/002_second.sql', 'CREATE TABLE second (id INTEGER);');
+        file_put_contents($this->fixturesPath . '/001_first.sql', 'CREATE TABLE first (id INTEGER);');
+
+        $runner = new MigrationRunner($this->db, $this->fixturesPath);
+        $files = $runner->discoverMigrationFiles();
+
+        self::assertSame(['001', '002'], array_keys($files));
+    }
+
+    public function testDiscoverMigrationFilesRejectsInvalidNamesAndDuplicates(): void
+    {
+        file_put_contents($this->fixturesPath . '/001_valid.sql', 'CREATE TABLE valid (id INTEGER);');
+        file_put_contents($this->fixturesPath . '/001_duplicate.sql', 'CREATE TABLE duplicate (id INTEGER);');
+        file_put_contents($this->fixturesPath . '/notes.sql', 'CREATE TABLE notes (id INTEGER);');
+
+        $runner = new MigrationRunner($this->db, $this->fixturesPath);
+
+        $this->expectException(RuntimeException::class);
+        $runner->discoverMigrationFiles();
+    }
+
+    public function testRunAllAppliesEveryPendingMigrationInOrder(): void
+    {
+        file_put_contents($this->fixturesPath . '/001_a.sql', 'CREATE TABLE a (id INTEGER);');
+        file_put_contents($this->fixturesPath . '/002_b.sql', 'CREATE TABLE b (id INTEGER);');
+
+        $runner = new MigrationRunner($this->db, $this->fixturesPath);
+        $runner->runAll();
+
+        self::assertSame(['001', '002'], $runner->appliedVersions());
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Adds a structured backend job-sync architecture with PSR-4 autoloading, a versioned migration runner, and a Remotive API fetcher with retry logic.

## Type of change
- [x] `feat` — new feature or component
- [x] `refactor` — code restructuring (no behaviour change)

## What changed?
- Added `App\Contracts\JobFetcherInterface` and `App\Contracts\JobNormalizerInterface` for clean source abstraction
- Implemented `RemotiveFetcher` with 3-retry exponential backoff and per-category failure degradation
- Added `MigrationRunner` class with transactional apply, rollback on failure, and schema_migrations tracking
- Created 2 idempotent SQL migrations: initial schema (001) and last_synced_at + sync_log enhancements (002)
- Added `CurlHttpClient` and `HttpClientInterface` for testable HTTP transport
- Added `NormalizedJob` immutable value object and `SourceUnavailableException` / `InvalidJobRecordException`
- Configured PSR-4 autoloading for `App\` and `Tests\` namespaces in composer.json
- Added PHPUnit configuration and tests for MigrationRunner (4 tests) and RemotiveFetcher (7 tests)
- Added `cron/migrate.php` CLI entry point with `composer migrate` script

## How was this tested?
- `composer test` — all 11 new tests pass (MigrationRunner: 4, RemotiveFetcher: 7)
- `composer format:check` — no formatting issues
- MigrationRunner tests use SQLite in-memory (no MySQL dependency)

## Notes for reviewers
- SQL migrations use `information_schema` guards — safe to re-run on existing databases
- RemotiveFetcher respects Remotive's 4-fetches/day rate limit via cron scheduling, not class-level throttling

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NaiDevOpsCom/nairobidevops.org-v2/364)
<!-- Reviewable:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend job-sync foundation with PSR-4 autoloading, a versioned migration runner, and a resilient Remotive fetcher with retries. Also adds a canonical initial schema and explicit sync run statuses for clearer monitoring.

- **New Features**
  - Introduced `JobFetcherInterface`/`JobNormalizerInterface`, `NormalizedJob`, and an HTTP client abstraction (`HttpClientInterface`/`CurlHttpClient`) for testable fetchers.
  - Added `RemotiveFetcher` with 3-attempt exponential backoff and per-category isolation; throws on partial or full-category failures.
  - Implemented `MigrationRunner` with transactional apply and `schema_migrations` tracking; CLI entry via `composer migrate` (`cron/migrate.php`).
  - Updated cron workers to write `sync_log.status` (`success`/`partial`) and improved expire job logging.
  - Enabled PSR-4 autoloading for `App\` and `Tests\`; added PHPUnit config and tests for fetcher and migrations.

- **Migration**
  - Requires PHP `>=8.4.0 <8.6.0`.
  - Run `composer install` then `composer migrate` to apply `003_initial_schema.sql` and `002_add_last_synced_at.sql` (adds `last_synced_at`, `sync_log.status`, `jobs_updated`, plus indexes). Includes a fix to status backfill quoting in `002` (correct string delimiters).

<sup>Written for commit ccacc1187ca4a946d7e1a5f01a660853353e9822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NaiDevOpsCom/nairobidevops.org-v2/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

